### PR TITLE
Extend Verify endpoint to include user's ID and auth level in response

### DIFF
--- a/entities/user.go
+++ b/entities/user.go
@@ -10,7 +10,7 @@ type User struct {
 	ID            primitive.ObjectID `json:"_id" bson:"_id"`
 	Name          string             `json:"name" bson:"name" validate:"required"`
 	Email         string             `json:"email" bson:"email" validate:"required,email"`
-	Password      string             `json:"password" bson:"password" validate:"required,min=6,max=160"`
+	Password      string             `json:"-" bson:"password" validate:"required,min=6,max=160"`
 	EmailVerified bool               `json:"email_verified,omitempty" bson:"email_verified,omitempty"`
 	EmailToken    string             `json:"email_token,omitempty" bson:"email_token,omitempty"`
 	AuthLevel     common.AuthLevel   `json:"auth_level,omitempty" bson:"auth_level,omitempty" validate:"min=0,max=3"`

--- a/entities/user_test.go
+++ b/entities/user_test.go
@@ -1,0 +1,26 @@
+package entities
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func Test_Password__should_be_ommitted_when_marshalling_user_to_JSON(t *testing.T) {
+	user := User{
+		ID:       primitive.NewObjectID(),
+		Password: "test password",
+	}
+
+	userJSON, err := json.Marshal(user)
+	assert.NoError(t, err)
+
+	var unmarshalledUser User
+	err = json.Unmarshal(userJSON, &unmarshalledUser)
+	assert.NoError(t, err)
+
+	assert.Empty(t, unmarshalledUser.Password)
+}

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,9 @@ github.com/sendgrid/rest v2.4.1+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV
 github.com/sendgrid/sendgrid-go v3.5.0+incompatible h1:kosbgHyNVYVaqECDYvFVLVD9nvThweBd6xp7vaCT3GI=
 github.com/sendgrid/sendgrid-go v3.5.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/routers/api/v1/router.go
+++ b/routers/api/v1/router.go
@@ -28,6 +28,7 @@ type APIV1Router interface {
 	LeaveTeam(*gin.Context)
 	JoinTeam(*gin.Context)
 	GetTeamMembers(*gin.Context)
+	GetPasswordResetEmail(*gin.Context)
 }
 
 type apiV1Router struct {
@@ -67,6 +68,7 @@ func (r *apiV1Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	usersGroup.GET("/verify", isAtLeastApplicant, r.Verify)
 	usersGroup.GET("/me", isAtLeastApplicant, r.GetMe)
 	usersGroup.PUT("/me", isAtLeastApplicant, r.PutMe)
+	usersGroup.GET("/password/reset", isAtLeastApplicant, r.GetPasswordResetEmail)
 
 	teamsGroup := routerGroup.Group("/teams")
 	teamsGroup.GET("/", isAtLeastOrganizer, r.GetTeams)

--- a/routers/api/v1/router.go
+++ b/routers/api/v1/router.go
@@ -29,6 +29,7 @@ type APIV1Router interface {
 	JoinTeam(*gin.Context)
 	GetTeamMembers(*gin.Context)
 	GetPasswordResetEmail(*gin.Context)
+	ResetPassword(*gin.Context)
 }
 
 type apiV1Router struct {
@@ -68,7 +69,8 @@ func (r *apiV1Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	usersGroup.GET("/verify", isAtLeastApplicant, r.Verify)
 	usersGroup.GET("/me", isAtLeastApplicant, r.GetMe)
 	usersGroup.PUT("/me", isAtLeastApplicant, r.PutMe)
-	usersGroup.GET("/password/reset", isAtLeastApplicant, r.GetPasswordResetEmail)
+	usersGroup.GET("/password/reset", r.GetPasswordResetEmail)
+	usersGroup.PUT("/password/reset", r.ResetPassword)
 
 	teamsGroup := routerGroup.Group("/teams")
 	teamsGroup.GET("/", isAtLeastOrganizer, r.GetTeams)

--- a/routers/api/v1/router_test.go
+++ b/routers/api/v1/router_test.go
@@ -104,6 +104,10 @@ func Test_RegisterRoutes__should_register_required_routes(t *testing.T) {
 			route:  "/users/password/reset",
 			method: http.MethodGet,
 		},
+		{
+			route:  "/users/password/reset",
+			method: http.MethodPut,
+		},
 	}
 
 	for _, tt := range tests {
@@ -188,11 +192,6 @@ func Test_RegisterRoutes__should_set_up_required_auth_verification(t *testing.T)
 		},
 		{
 			route:        "/teams/123abd/members",
-			method:       http.MethodGet,
-			minAuthLevel: authlevels.Applicant,
-		},
-		{
-			route:        "/users/password/reset",
 			method:       http.MethodGet,
 			minAuthLevel: authlevels.Applicant,
 		},

--- a/routers/api/v1/router_test.go
+++ b/routers/api/v1/router_test.go
@@ -100,6 +100,10 @@ func Test_RegisterRoutes__should_register_required_routes(t *testing.T) {
 			route:  "/teams/123abd/members",
 			method: http.MethodGet,
 		},
+		{
+			route:  "/users/password/reset",
+			method: http.MethodGet,
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +188,11 @@ func Test_RegisterRoutes__should_set_up_required_auth_verification(t *testing.T)
 		},
 		{
 			route:        "/teams/123abd/members",
+			method:       http.MethodGet,
+			minAuthLevel: authlevels.Applicant,
+		},
+		{
+			route:        "/users/password/reset",
 			method:       http.MethodGet,
 			minAuthLevel: authlevels.Applicant,
 		},

--- a/routers/api/v1/teams_test.go
+++ b/routers/api/v1/teams_test.go
@@ -47,7 +47,7 @@ type testSetup struct {
 	testCtx      *gin.Context
 	testServer   *gin.Engine
 	claims       *auth.Claims
-	emailToken        string
+	emailToken   string
 }
 
 func setupTeamTest(t *testing.T, envVars map[string]string, authLevel common.AuthLevel) *testSetup {

--- a/routers/api/v1/types.go
+++ b/routers/api/v1/types.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
+	"github.com/unicsmcr/hs_auth/utils/auth/common"
 )
 
 type getUsersRes struct {
@@ -18,6 +19,8 @@ type loginRes struct {
 
 type verifyRes struct {
 	models.Response
+	AuthLevel common.AuthLevel `json:"auth_level"`
+	UserID    string           `json:"user_id"`
 }
 
 type getMeRes struct {

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const passwordReplacementString = "************"
 const authClaimsKeyInCtx = "auth_claims"
 
 // AuthLevelVerifierFactory creates a middleware that checks if the user's
@@ -52,7 +51,6 @@ func (r *apiV1Router) GetUsers(ctx *gin.Context) {
 		return
 	}
 	for i := 0; i < len(users); i++ {
-		users[i].Password = passwordReplacementString
 	}
 
 	ctx.JSON(http.StatusOK, getUsersRes{
@@ -104,7 +102,6 @@ func (r *apiV1Router) Login(ctx *gin.Context) {
 		models.SendAPIError(ctx, http.StatusUnauthorized, "user not found")
 		return
 	}
-	user.Password = passwordReplacementString
 
 	if !user.EmailVerified {
 		r.logger.Warn("user's email not verified'", zap.String("user id", user.ID.Hex()), zap.String("email", email))
@@ -168,7 +165,6 @@ func (r *apiV1Router) GetMe(ctx *gin.Context) {
 		}
 		return
 	}
-	user.Password = passwordReplacementString
 	ctx.JSON(http.StatusOK, getMeRes{
 		User: *user,
 	})
@@ -283,7 +279,6 @@ func (r *apiV1Router) Register(ctx *gin.Context) {
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong while creating new user")
 		return
 	}
-	user.Password = passwordReplacementString
 
 	// TODO: change validityDuration placeholder once token validity duration is implemented
 	emailToken, err := auth.NewJWT(*user, time.Now().Unix(), 0, auth.Email, []byte(r.env.Get(environment.JWTSecret)))

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -20,7 +20,7 @@ const authClaimsKeyInCtx = "auth_claims"
 
 // AuthLevelVerifierFactory creates a middleware that checks if the user's
 // auth token has the required auth level and attaches the auth claims to
-// the reques context. Will return a 401 if the auth token is invalid or has
+// the request context. Will return a 401 if the auth token is invalid or has
 // an auth level that is too low
 func (r *apiV1Router) AuthLevelVerifierFactory(level authlevels.AuthLevel) func(*gin.Context) {
 	return func(ctx *gin.Context) {

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -324,7 +324,7 @@ func (r *apiV1Router) VerifyEmail(ctx *gin.Context) {
 	token := ctx.Query("token")
 	if len(token) == 0 {
 		r.logger.Warn("token not specified")
-		models.SendAPIError(ctx, http.StatusBadRequest, "no token specified")
+		models.SendAPIError(ctx, http.StatusUnauthorized, "invalid token")
 		return
 	}
 

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -114,7 +114,7 @@ func (r *apiV1Router) Login(ctx *gin.Context) {
 
 	token, err := auth.NewJWT(*user, time.Now().Unix(), 0, auth.Auth, []byte(r.env.Get(environment.JWTSecret)))
 	if err != nil {
-		r.logger.Error("could not create JWT", zap.Any("user", *user), zap.Error(err))
+		r.logger.Error("could not create JWT", zap.String("user", user.ID.Hex()), zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "there was a problem with creating authentication token")
 		return
 	}

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -50,8 +50,6 @@ func (r *apiV1Router) GetUsers(ctx *gin.Context) {
 		models.SendAPIError(ctx, http.StatusInternalServerError, err.Error())
 		return
 	}
-	for i := 0; i < len(users); i++ {
-	}
 
 	ctx.JSON(http.StatusOK, getUsersRes{
 		Response: models.Response{

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -314,12 +314,12 @@ func (r *apiV1Router) Register(ctx *gin.Context) {
 	})
 }
 
-// POST: /api/v1/users/email?token={token}
-// Request:  token string
+// POST: /api/v1/users/email
 // Response: status int
 //           error string
+// Header:   Authorization -> token
 func (r *apiV1Router) VerifyEmail(ctx *gin.Context) {
-	token := ctx.Query("token")
+	token := ctx.GetHeader(authHeaderName)
 	if len(token) == 0 {
 		r.logger.Warn("token not specified")
 		models.SendAPIError(ctx, http.StatusUnauthorized, "invalid token")

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -130,6 +130,11 @@ func (r *apiV1Router) Login(ctx *gin.Context) {
 // Headers:  Authorization -> token
 func (r *apiV1Router) Verify(ctx *gin.Context) {
 	claims := extractClaimsFromCtx(ctx)
+	if claims == nil {
+		r.logger.Warn("could not extract auth claims from request context")
+		models.SendAPIError(ctx, http.StatusBadRequest, "missing auth information")
+		return
+	}
 
 	r.logger.Info("claims", zap.Any("claims", claims))
 	ctx.JSON(http.StatusOK, verifyRes{

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -141,6 +141,8 @@ func (r *apiV1Router) Verify(ctx *gin.Context) {
 		Response: models.Response{
 			Status: http.StatusOK,
 		},
+		AuthLevel: claims.AuthLevel,
+		UserID:    claims.Id,
 	})
 }
 

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -348,21 +348,30 @@ func (r *apiV1Router) VerifyEmail(ctx *gin.Context) {
 	})
 }
 
-// GET: /api/v1/users/password/reset
-// Request:  token string
+// GET: /api/v1/users/password/reset?email={email}
+// Request:  email string
 // Response: status int
 //           error string
 func (r *apiV1Router) GetPasswordResetEmail(ctx *gin.Context) {
-	claims := extractClaimsFromCtx(ctx)
-	if claims == nil {
-		r.logger.Warn("could not extract auth claims from request context")
-		models.SendAPIError(ctx, http.StatusBadRequest, "missing auth information")
+	email := ctx.Query("email")
+	if len(email) == 0 {
+		r.logger.Warn("email not specified")
+		models.SendAPIError(ctx, http.StatusBadRequest, "email must be specified")
 		return
 	}
 
-	user, err := r.userService.GetUserWithID(ctx, claims.Id)
+	user, err := r.userService.GetUserWithEmail(ctx, email)
 	if err != nil {
-		r.logger.Error("could not fetch user", zap.String("id", claims.Id), zap.Error(err))
+		if err == services.ErrNotFound {
+			r.logger.Warn("user with email doesn't exist", zap.String("email", email))
+			// don't want to give the user a tool to figure which email addresses are registered
+			// as this would be a security issue
+			ctx.JSON(http.StatusOK, models.Response{
+				Status: http.StatusOK,
+			})
+			return
+		}
+		r.logger.Error("could not fetch user", zap.String("email", email), zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
 		return
 	}
@@ -370,7 +379,7 @@ func (r *apiV1Router) GetPasswordResetEmail(ctx *gin.Context) {
 	emailToken, err := auth.NewJWT(*user, time.Now().Unix(), 100, auth.Email, []byte(r.env.Get(environment.JWTSecret)))
 	if err != nil {
 		r.logger.Error("could not make email token for user",
-			zap.String("user id", claims.Id),
+			zap.String("user id", user.ID.Hex()),
 			zap.String("jwt secret env var name", environment.JWTSecret),
 			zap.Bool("jwt secret set", r.env.Get(environment.JWTSecret) == environment.DefaultEnvVarValue),
 			zap.Error(err))
@@ -381,6 +390,76 @@ func (r *apiV1Router) GetPasswordResetEmail(ctx *gin.Context) {
 	err = r.emailService.SendPasswordResetEmail(*user, emailToken)
 	if err != nil {
 		r.logger.Error("could not send password reset email", zap.String("user id", user.ID.Hex()), zap.Error(err))
+		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		return
+	}
+
+	ctx.JSON(http.StatusOK, models.Response{
+		Status: http.StatusOK,
+	})
+}
+
+// PUT: /api/v1/users/password/reset?email={email}
+// Request:  email string
+//           password string (x-www-form-urlencoded)
+// Response: status int
+//           error string
+// Header:   Authorization -> token
+func (r *apiV1Router) ResetPassword(ctx *gin.Context) {
+	email := ctx.Query("email")
+	if len(email) == 0 {
+		r.logger.Warn("email not specified")
+		models.SendAPIError(ctx, http.StatusBadRequest, "email must be specified")
+		return
+	}
+
+	password := ctx.PostForm("password")
+	if len(password) == 0 {
+		r.logger.Warn("password not specified")
+		models.SendAPIError(ctx, http.StatusBadRequest, "password must be specified")
+		return
+	}
+
+	token := ctx.GetHeader(authHeaderName)
+	if len(token) == 0 {
+		r.logger.Warn("token not specified")
+		models.SendAPIError(ctx, http.StatusUnauthorized, "invalid token")
+		return
+	}
+
+	claims := auth.GetJWTClaims(token, []byte(r.env.Get(environment.JWTSecret)))
+	if claims == nil || claims.TokenType != auth.Email {
+		r.logger.Warn("invalid token")
+		models.SendAPIError(ctx, http.StatusUnauthorized, "invalid token")
+		return
+	}
+
+	user, err := r.userService.GetUserWithID(ctx, claims.Id)
+	if err != nil {
+		r.logger.Error("could not fetch user", zap.String("user id", claims.Id), zap.Error(err))
+		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		return
+	}
+
+	if user.Email != email {
+		r.logger.Warn("user's in token email is different than email in request", zap.String("user's email", user.Email), zap.String("given email", email))
+		models.SendAPIError(ctx, http.StatusUnauthorized, "invalid token")
+		return
+	}
+
+	hashedPassword, err := auth.GetHashForPassword(password)
+	if err != nil {
+		r.logger.Error("could not make hash for password", zap.Error(err))
+		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong while creating new user")
+		return
+	}
+
+	user.Password = hashedPassword
+	err = r.userService.UpdateUserWithID(ctx, claims.Id, map[string]interface{}{
+		"password": user.Password,
+	})
+	if err != nil {
+		r.logger.Error("could not user's password", zap.String("user id", user.ID.Hex()), zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
 		return
 	}

--- a/routers/api/v1/users_test.go
+++ b/routers/api/v1/users_test.go
@@ -705,62 +705,6 @@ func Test_VerifyEmail(t *testing.T) {
 	}
 }
 
-func Test_VerifyEmail(t *testing.T) {
-	tests := []struct {
-		name        string
-		token       string
-		wantResCode int
-		prep        func(userID string, mockUService *mock_services.MockUserService)
-	}{
-		{
-			name:        "should return 401 when no token is specified",
-			wantResCode: http.StatusUnauthorized,
-		},
-		{
-			name:        "should return 401 when token is invalid",
-			token:       "notvalidtoken",
-			wantResCode: http.StatusUnauthorized,
-		},
-		{
-			name:  "should return 500 when email service returns error",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1ZDdhOTM4NmU0OGZhMTY1NTZjNTY0MTEiLCJpYXQiOjEwMCwiYXV0aF9sZXZlbCI6MywidG9rZW5fdHlwZSI6ImVtYWlsIn0.Hsi2STFazVwcQ73sG8BKg3dmIx_XnijFoJx6BNYuGPc",
-			prep: func(userID string, mockUService *mock_services.MockUserService) {
-				mockUService.EXPECT().UpdateUserWithID(gomock.Any(), userID, map[string]interface{}{
-					"email_verified": true,
-				}).Return(errors.New("service err")).Times(1)
-			},
-			wantResCode: http.StatusInternalServerError,
-		},
-		{
-			name:  "should return 200 when everything is alright",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1ZDdhOTM4NmU0OGZhMTY1NTZjNTY0MTEiLCJpYXQiOjEwMCwiYXV0aF9sZXZlbCI6MywidG9rZW5fdHlwZSI6ImVtYWlsIn0.Hsi2STFazVwcQ73sG8BKg3dmIx_XnijFoJx6BNYuGPc",
-			prep: func(userID string, mockUService *mock_services.MockUserService) {
-				mockUService.EXPECT().UpdateUserWithID(gomock.Any(), userID, map[string]interface{}{
-					"email_verified": true,
-				}).Return(nil).Times(1)
-			},
-			wantResCode: http.StatusOK,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockUService, _, w, testCtx, _, router, testUser, _ := setupTest(t, map[string]string{
-				environment.JWTSecret: "testsecret",
-			})
-			if tt.prep != nil {
-				tt.prep(testUser.ID.Hex(), mockUService)
-			}
-
-			req := httptest.NewRequest("GET", fmt.Sprintf("/test?token=%s", tt.token), nil)
-			testCtx.Request = req
-
-			router.VerifyEmail(testCtx)
-			assert.Equal(t, tt.wantResCode, w.Code)
-		})
-	}
-}
-
 func Test_AuthLevelVerifierFactory__should_return_middleware(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/routers/api/v1/users_test.go
+++ b/routers/api/v1/users_test.go
@@ -906,28 +906,37 @@ func Test_PutMe(t *testing.T) {
 func Test_GetPasswordResetEmail(t *testing.T) {
 	tests := []struct {
 		name        string
+		email       string
 		prep        func(*testSetup)
 		wantResCode int
 	}{
 		{
-			name: "should return 400 when auth claims are missing from request's context",
-			prep: func(setup *testSetup) {
-				setup.testCtx.Set(authClaimsKeyInCtx, nil)
-			},
+			name:        "should return 400 when request doesn't include an email",
 			wantResCode: http.StatusBadRequest,
 		},
 		{
-			name: "should return 500 when query for user fails",
+			name:  "should return 500 when query for user fails",
+			email: "john@doe.com",
 			prep: func(setup *testSetup) {
-				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.testUser.ID.Hex()).
+				setup.mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "john@doe.com").
 					Return(nil, errors.New("service err")).Times(1)
 			},
 			wantResCode: http.StatusInternalServerError,
 		},
 		{
-			name: "should return 500 when query to email service fails",
+			name:  "should return 200 when user with email doesn't exist",
+			email: "john@doe.com",
 			prep: func(setup *testSetup) {
-				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.testUser.ID.Hex()).
+				setup.mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "john@doe.com").
+					Return(nil, services.ErrNotFound).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+		{
+			name:  "should return 500 when query to email service fails",
+			email: "john@doe.com",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "john@doe.com").
 					Return(setup.testUser, nil).Times(1)
 				setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser, gomock.Any()).
 					Return(errors.New("service err")).Times(1)
@@ -935,9 +944,10 @@ func Test_GetPasswordResetEmail(t *testing.T) {
 			wantResCode: http.StatusInternalServerError,
 		},
 		{
-			name: "should return 200 when all is good",
+			name:  "should return 200 when all is good",
+			email: "john@doe.com",
 			prep: func(setup *testSetup) {
-				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.testUser.ID.Hex()).
+				setup.mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "john@doe.com").
 					Return(setup.testUser, nil).Times(1)
 				setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser, gomock.Any()).
 					Return(nil).Times(1)
@@ -955,7 +965,128 @@ func Test_GetPasswordResetEmail(t *testing.T) {
 				tt.prep(setup)
 			}
 
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/test?email=%s", tt.email), nil)
+			setup.testCtx.Request = req
 			setup.router.GetPasswordResetEmail(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+		})
+	}
+}
+
+func Test_ResetPassword(t *testing.T) {
+	tests := []struct {
+		name        string
+		email       string
+		token       string
+		customToken bool
+		password    string
+		prep        func(*testSetup)
+		wantResCode int
+	}{
+		{
+			name:        "should return 400 when email is not provided",
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:        "should return 400 when password is not provided",
+			email:       "john@doe.com",
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:        "should return 401 when token is not provided",
+			email:       "john@doe.com",
+			password:    "password123",
+			customToken: true,
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:        "should return 401 when token is not valid",
+			email:       "john@doe.com",
+			password:    "password123",
+			customToken: true,
+			token:       "invalid token",
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:        "should return 401 when token is not an email token",
+			email:       "john@doe.com",
+			password:    "password123",
+			customToken: true,
+			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1ZDgxMmFiNTI2YTc5MjYxYjZjMWVlNWEiLCJpYXQiOjEwMCwiYXV0aF9sZXZlbCI6MCwidG9rZW5fdHlwZSI6ImF1dGgifQ.Pw6ojEkWRU5Nr84MUppWaAIoxuy9CAFW6yzvSRQ9QyE",
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "should return 500 when query for user fails",
+			email:    "john@doe.com",
+			password: "password123",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.claims.Id).
+					Return(nil, errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "should return 401 when user's email is different from the specified email",
+			email:    "john@doe.com",
+			password: "password123",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.claims.Id).
+					Return(&entities.User{
+						Email: "jane@doe.com",
+					}, nil).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "should return 500 when query to update user's password fails",
+			email:    "john@doe.com",
+			password: "password123",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.claims.Id).
+					Return(setup.testUser, nil).Times(1)
+				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), setup.claims.Id, gomock.Any()).
+					Return(errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "should return 200 when all is good",
+			email:    "john@doe.com",
+			password: "password123",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(gomock.Any(), setup.claims.Id).
+					Return(setup.testUser, nil).Times(1)
+				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), setup.claims.Id, gomock.Any()).
+					Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupUserTest(t, map[string]string{
+				environment.JWTSecret: "supersecret",
+			}, 0)
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.testCtx.Set(authClaimsKeyInCtx, nil)
+
+			data := url.Values{}
+			data.Add("password", tt.password)
+
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/test?email=%s", tt.email), bytes.NewBufferString(data.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
+			if !tt.customToken {
+				req.Header.Set(authHeaderName, setup.emailToken)
+			} else {
+				req.Header.Set(authHeaderName, tt.token)
+			}
+			setup.testCtx.Request = req
+			setup.router.ResetPassword(setup.testCtx)
 
 			assert.Equal(t, tt.wantResCode, setup.w.Code)
 		})

--- a/routers/api/v1/users_test.go
+++ b/routers/api/v1/users_test.go
@@ -229,6 +229,7 @@ func Test_Login__should_call_UserService_and_return_correct_token_and_user(t *te
 	assert.Equal(t, testUser.AuthLevel, claims.AuthLevel)
 
 	assert.NotNil(t, auth.GetJWTClaims(actualRes.Token, []byte("testsecret")))
+	testUser.Password = actualRes.User.Password
 	assert.Equal(t, testUser, actualRes.User)
 }
 
@@ -394,8 +395,7 @@ func Test_GetMe__should_return_correct_user(t *testing.T) {
 	err = json.Unmarshal([]byte(actualResStr), &actualRes)
 	assert.NoError(t, err)
 
-	testUser.Password = passwordReplacementString
-
+	testUser.Password = actualRes.User.Password
 	assert.Equal(t, testUser, actualRes.User)
 }
 
@@ -461,68 +461,6 @@ func Test_Login__should_return_401_when_users_password_is_incorrect(t *testing.T
 	router.Login(testCtx)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-}
-
-func Test_Login__should_return_user_with_hidden_password(t *testing.T) {
-	mockUService, _, w, testCtx, _, router, testUser, _ := setupTest(t, map[string]string{
-		environment.JWTSecret: "supersecret",
-	})
-
-	mockUService.EXPECT().GetUserWithEmail(gomock.Any(), gomock.Any()).
-		Return(&testUser, nil).Times(1)
-
-	data := url.Values{}
-	data.Add("email", "john@doe.com")
-	data.Add("password", "password123")
-
-	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(data.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
-	testCtx.Request = req
-
-	router.Login(testCtx)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	actualResStr, err := w.Body.ReadString('\x00')
-	assert.Equal(t, "EOF", err.Error())
-
-	var actualRes loginRes
-	err = json.Unmarshal([]byte(actualResStr), &actualRes)
-	assert.NoError(t, err)
-
-	testUser.Password = passwordReplacementString
-
-	assert.Equal(t, testUser, actualRes.User)
-}
-
-func Test_GetUsers__return_users_with_hidden_passwords(t *testing.T) {
-	mockUService, _, w, testCtx, _, router, _, token := setupTest(t, map[string]string{
-		environment.JWTSecret: "testsecret",
-	})
-
-	expectedRes := getUsersRes{
-		Response: models.Response{
-			Status: http.StatusOK,
-		},
-		Users: []entities.User{entities.User{Name: "Bob Tester", Password: "some password"}},
-	}
-	mockUService.EXPECT().GetUsers(gomock.Any()).Return(expectedRes.Users, nil).Times(1)
-
-	req := httptest.NewRequest(http.MethodPost, "/test", nil)
-	req.Header.Set(authHeaderName, token)
-	testCtx.Request = req
-	router.GetUsers(testCtx)
-
-	actualResStr, err := w.Body.ReadString('\x00')
-	assert.Equal(t, "EOF", err.Error())
-
-	var actualRes getUsersRes
-	err = json.Unmarshal([]byte(actualResStr), &actualRes)
-
-	expectedRes.Users[0].Password = passwordReplacementString
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, expectedRes, actualRes)
 }
 
 func Test_Register__should_return_400_if_name_is_unspecified(t *testing.T) {
@@ -708,8 +646,7 @@ func Test_Register__should_return_200_and_correct_user(t *testing.T) {
 	err = json.Unmarshal([]byte(actualResStr), &actualRes)
 	assert.NoError(t, err)
 
-	assert.Equal(t, testUser, actualRes.User)
-	assert.Equal(t, passwordReplacementString, actualRes.User.Password)
+	assert.Equal(t, testUser.ID, actualRes.User.ID)
 }
 
 func Test_VerifyEmail(t *testing.T) {

--- a/routers/api/v1/users_test.go
+++ b/routers/api/v1/users_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -709,6 +710,62 @@ func Test_Register__should_return_200_and_correct_user(t *testing.T) {
 
 	assert.Equal(t, testUser, actualRes.User)
 	assert.Equal(t, passwordReplacementString, actualRes.User.Password)
+}
+
+func Test_VerifyEmail(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		wantResCode int
+		prep        func(userID string, mockUService *mock_services.MockUserService)
+	}{
+		{
+			name:        "should return 401 when no token is specified",
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:        "should return 401 when token is invalid",
+			token:       "notvalidtoken",
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:  "should return 500 when email service returns error",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1ZDdhOTM4NmU0OGZhMTY1NTZjNTY0MTEiLCJpYXQiOjEwMCwiYXV0aF9sZXZlbCI6MywidG9rZW5fdHlwZSI6ImVtYWlsIn0.Hsi2STFazVwcQ73sG8BKg3dmIx_XnijFoJx6BNYuGPc",
+			prep: func(userID string, mockUService *mock_services.MockUserService) {
+				mockUService.EXPECT().UpdateUserWithID(gomock.Any(), userID, map[string]interface{}{
+					"email_verified": true,
+				}).Return(errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:  "should return 200 when everything is alright",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI1ZDdhOTM4NmU0OGZhMTY1NTZjNTY0MTEiLCJpYXQiOjEwMCwiYXV0aF9sZXZlbCI6MywidG9rZW5fdHlwZSI6ImVtYWlsIn0.Hsi2STFazVwcQ73sG8BKg3dmIx_XnijFoJx6BNYuGPc",
+			prep: func(userID string, mockUService *mock_services.MockUserService) {
+				mockUService.EXPECT().UpdateUserWithID(gomock.Any(), userID, map[string]interface{}{
+					"email_verified": true,
+				}).Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUService, _, w, testCtx, _, router, testUser, _ := setupTest(t, map[string]string{
+				environment.JWTSecret: "testsecret",
+			})
+			if tt.prep != nil {
+				tt.prep(testUser.ID.Hex(), mockUService)
+			}
+
+			req := httptest.NewRequest("GET", fmt.Sprintf("/test?token=%s", tt.token), nil)
+			testCtx.Request = req
+
+			router.VerifyEmail(testCtx)
+			assert.Equal(t, tt.wantResCode, w.Code)
+		})
+	}
 }
 
 func Test_AuthLevelVerifierFactory__should_return_middleware(t *testing.T) {

--- a/services/emailService.go
+++ b/services/emailService.go
@@ -85,5 +85,12 @@ func (s *emailService) SendEmailVerificationEmail(user entities.User, emailToken
 }
 
 func (s *emailService) SendPasswordResetEmail(user entities.User, emailToken string) error {
-	return nil
+	return s.SendEmail(
+		s.cfg.Email.PasswordResetEmailSubj,
+		emailToken,
+		emailToken,
+		s.cfg.Email.NoreplyEmailName,
+		s.cfg.Email.NoreplyEmailAddr,
+		user.Name,
+		user.Email)
 }

--- a/testutils/testDB.go
+++ b/testutils/testDB.go
@@ -1,0 +1,46 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const dbUser = "hs_auth"
+const dbPassword = "password123"
+const dbAddress = "localhost:8003"
+const dbDatabase = "hs_auth"
+
+// ConnectToIntegrationTestDB waits for the integrations tests DB to become available
+// and returns a connection to the DB
+func ConnectToIntegrationTestDB(t *testing.T) *mongo.Database {
+	client, err := mongo.NewClient(options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s/%s", dbUser, dbPassword, dbAddress, dbDatabase)))
+	assert.NoError(t, err)
+
+	err = client.Connect(context.Background())
+	assert.NoError(t, err)
+
+	var db *mongo.Database
+	// Giving some time for the DB to boot up
+	retryCount := 0
+	for {
+		db = client.Database("hs_auth")
+		err := client.Ping(context.Background(), nil)
+		if err == nil {
+			break
+		} else if retryCount == 3 {
+			fmt.Println(err)
+			panic("could not connect to db")
+		}
+		retryCount++
+		fmt.Println("could not connect to database, will retry in a bit")
+		time.Sleep(5 * time.Second)
+	}
+
+	return db
+}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -1,17 +1,9 @@
 package testutils
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"reflect"
-	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/mongo/options"
-
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // SetEnvVars sets given environment variables and provides a callback function to restore the variables to their initial values
@@ -110,31 +102,4 @@ func (r RouterGroupMatcher) Matches(x interface{}) bool {
 
 func (r RouterGroupMatcher) String() string {
 	return fmt.Sprintf("router group's base path is %s", r.Path)
-}
-
-// ConnectToIntegrationTestDB waits for the integrations tests DB to become available
-// and returns a connection to the DB
-func ConnectToIntegrationTestDB(t *testing.T) *mongo.Database {
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://hs_auth:password123@localhost:8003/hs_auth"))
-	assert.NoError(t, err)
-
-	err = client.Connect(context.Background())
-	assert.NoError(t, err)
-
-	var db *mongo.Database
-	// Giving some time for the DB to boot up
-	for i := 0; i < 4; i++ {
-		db = client.Database("hs_auth")
-		err := client.Ping(context.Background(), nil)
-		if err == nil {
-			break
-		} else if i == 3 {
-			fmt.Println(err)
-			panic("could not connect to db")
-		}
-		fmt.Println("could not connect to database, will retry in a bit")
-		time.Sleep(5 * time.Second)
-	}
-
-	return db
 }

--- a/utils/auth/auth.go
+++ b/utils/auth/auth.go
@@ -28,8 +28,6 @@ type Claims struct {
 	TokenType TokenType        `json:"token_type"`
 }
 
-const lettersForEmailToken = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!"
-
 // GetJWTClaims checks if the given token is a valid JWT with given secret
 // and returns the claims inside the token. Returns nill if the token is invalid
 func GetJWTClaims(token string, secret []byte) *Claims {

--- a/utils/auth/auth.go
+++ b/utils/auth/auth.go
@@ -69,10 +69,10 @@ func GetHashForPassword(password string) (string, error) {
 	return string(hash), nil
 }
 
-// NewJWT creates a new JWT token for the specified user with the specified secret
+// NewJWT creates a new JWT for the specified user with the specified secret
 func NewJWT(user entities.User, timestamp int64, validityDuration time.Duration, tokenType TokenType, secret []byte) (string, error) {
 	if len(secret) == 0 {
-		return "", errors.New("JWT token secret undefined")
+		return "", errors.New("JWT secret undefined")
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &Claims{


### PR DESCRIPTION
Updated the `/api/v1/users/verify` endpoint to include the user's ID and auth level in the response. No changes to the request were made.