### PR TITLE
EmailService V2

### DIFF
--- a/services/emailService.go
+++ b/services/emailService.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -18,6 +19,17 @@ type EmailService interface {
 	SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error
 	SendEmailVerificationEmail(user entities.User, emailToken string) error
 	SendPasswordResetEmail(user entities.User, emailToken string) error
+}
+
+// EmailServiceV2 is used to send out emails
+type EmailServiceV2 interface {
+	SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error
+
+	SendEmailVerificationEmail(user entities.User) error
+	SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string) error
+
+	SendPasswordResetEmail(user entities.User) error
+	SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string) error
 }
 
 type emailService struct {

--- a/services/sendgrid/emailService.go
+++ b/services/sendgrid/emailService.go
@@ -1,0 +1,155 @@
+package sendgrid
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	"github.com/unicsmcr/hs_auth/config"
+	"github.com/unicsmcr/hs_auth/entities"
+	"github.com/unicsmcr/hs_auth/services"
+	"github.com/unicsmcr/hs_auth/utils"
+	"go.uber.org/zap"
+)
+
+var (
+	passwordResetEmailTemplatePath = "templates/emails/passwordReset_email.gohtml"
+	emailVerifyEmailTemplatePath   = "templates/emails/emailVerify_email.gohtml"
+)
+
+type sendgridEmailService struct {
+	*sendgrid.Client
+	logger      *zap.Logger
+	cfg         *config.AppConfig
+	userService services.UserService
+
+	passwordResetEmailTemplate *template.Template
+	emailVerifyEmailTemplate   *template.Template
+}
+
+type emailTemplateDataModel struct {
+	Link       string
+	SenderName string
+}
+
+func NewSendgridEmailService(logger *zap.Logger, cfg *config.AppConfig, client *sendgrid.Client, userService services.UserService) (services.EmailServiceV2, error) {
+	passwordResetEmailTemplate, err := utils.LoadTemplate("password reset", passwordResetEmailTemplatePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load password reset template")
+	}
+
+	emailVerifyEmailTemplate, err := utils.LoadTemplate("email verify", emailVerifyEmailTemplatePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load email verify template")
+	}
+
+	return &sendgridEmailService{
+		Client:                     client,
+		logger:                     logger,
+		cfg:                        cfg,
+		userService:                userService,
+		passwordResetEmailTemplate: passwordResetEmailTemplate,
+		emailVerifyEmailTemplate:   emailVerifyEmailTemplate,
+	}, nil
+}
+
+func (s *sendgridEmailService) SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error {
+	from := mail.NewEmail(senderName, senderEmail)
+	to := mail.NewEmail(recipientName, recipientEmail)
+	message := mail.NewSingleEmail(from, subject, to, plainTextBody, htmlBody)
+	response, err := s.Send(message)
+
+	if err != nil {
+		s.logger.Error("could not issue email request",
+			zap.String("subject", subject),
+			zap.String("recipient", recipientEmail),
+			zap.String("sender", senderEmail),
+			zap.Error(err))
+		return errors.Wrap(err, "could not send email request to SendGrid")
+	}
+
+	if response.StatusCode != http.StatusAccepted {
+		s.logger.Error("email request was rejected by Sendgrid",
+			zap.String("subject", subject),
+			zap.String("recipient", recipientEmail),
+			zap.String("sender", senderEmail),
+			zap.Int("response status code", response.StatusCode),
+			zap.String("response body", response.Body))
+		return services.ErrSendgridRejectedRequest
+	}
+
+	s.logger.Info("email request sent successfully",
+		zap.String("subject", subject),
+		zap.String("recipient", recipientEmail),
+		zap.String("sender", senderEmail))
+	return nil
+}
+func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User) error {
+	// TODO: make email token
+	emailToken := ""
+
+	verificationURL := fmt.Sprintf("http://%s/verifyemail?token=%s", s.cfg.AppURL, emailToken)
+
+	var contentBuff bytes.Buffer
+	err := s.passwordResetEmailTemplate.Execute(&contentBuff, emailTemplateDataModel{
+		Link:       verificationURL,
+		SenderName: s.cfg.Email.NoreplyEmailName,
+	})
+	if err != nil {
+		return errors.Wrap(err, "could not construct email")
+	}
+
+	return s.SendEmail(
+		s.cfg.Email.EmailVerficationEmailSubj,
+		contentBuff.String(),
+		contentBuff.String(),
+		s.cfg.Email.NoreplyEmailName,
+		s.cfg.Email.NoreplyEmailAddr,
+		user.Name,
+		user.Email)
+}
+func (s *sendgridEmailService) SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string) error {
+	user, err := s.userService.GetUserWithEmail(ctx, email)
+	if err != nil {
+		return err
+	}
+
+	return s.SendEmailVerificationEmail(*user)
+}
+func (s *sendgridEmailService) SendPasswordResetEmail(user entities.User) error {
+	// TODO: make email token
+	emailToken := ""
+
+	resetURL := fmt.Sprintf("http://%s/resetpwd?email=%s&token=%s", s.cfg.AppURL, user.Email, emailToken)
+
+	var contentBuff bytes.Buffer
+	err := s.passwordResetEmailTemplate.Execute(&contentBuff, emailTemplateDataModel{
+		Link:       resetURL,
+		SenderName: s.cfg.Email.NoreplyEmailName,
+	})
+	if err != nil {
+		return errors.Wrap(err, "could not construct email")
+	}
+
+	return s.SendEmail(
+		s.cfg.Email.PasswordResetEmailSubj,
+		contentBuff.String(),
+		contentBuff.String(),
+		s.cfg.Email.NoreplyEmailName,
+		s.cfg.Email.NoreplyEmailAddr,
+		user.Name,
+		user.Email)
+}
+func (s *sendgridEmailService) SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string) error {
+	user, err := s.userService.GetUserWithEmail(ctx, email)
+	if err != nil {
+		return err
+	}
+
+	return s.SendPasswordResetEmail(*user)
+}

--- a/services/sendgrid/emailService_test.go
+++ b/services/sendgrid/emailService_test.go
@@ -1,0 +1,1 @@
+package sendgrid

--- a/services/sendgrid/emailService_test.go
+++ b/services/sendgrid/emailService_test.go
@@ -1,1 +1,244 @@
 package sendgrid
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/unicsmcr/hs_auth/services"
+
+	"github.com/golang/mock/gomock"
+	mock_services "github.com/unicsmcr/hs_auth/mocks/services"
+
+	"github.com/unicsmcr/hs_auth/entities"
+
+	"github.com/unicsmcr/hs_auth/config"
+
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sendgrid/sendgrid-go"
+)
+
+const (
+	_sendgridAPIKey    = "testkey"
+	_testEmailTemplate = "testEmailTemplate.txt"
+)
+
+type response struct {
+	message string
+	status  int
+}
+
+func getTestClient(t *testing.T, expectedRequestBody string, wantResponse response) (*sendgrid.Client, *httptest.Server) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(expectedRequestBody) != 0 {
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedRequestBody, string(body))
+		}
+		w.WriteHeader(wantResponse.status)
+		w.Write([]byte(wantResponse.message))
+	}))
+
+	req := sendgrid.GetRequest(_sendgridAPIKey, "/", server.URL)
+	req.Method = http.MethodPost
+	client := sendgrid.Client{
+		Request: req,
+	}
+
+	return &client, server
+}
+
+func Test_NewSendgridEmailService__should_return_error_when_template_path_is_incorrect(t *testing.T) {
+	// password reset
+	passwordResetEmailTemplatePath = "invalid path"
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	service, err := NewSendgridEmailService(nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+
+	// email verify
+	emailVerifyEmailTemplatePath = "invalid path"
+	passwordResetEmailTemplatePath = _testEmailTemplate
+
+	service, err = NewSendgridEmailService(nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+}
+
+func Test_SendEmail__should_send_correct_message_to_sendgrid(t *testing.T) {
+	passwordResetEmailTemplatePath = "testEmailTemplate.txt"
+	emailVerifyEmailTemplatePath = "testEmailTemplate.txt"
+
+	client, server := getTestClient(t, `{"from":{"name":"Bob the Tester","email":"bob@test.com"},"subject":"test email","personalizations":[{"to":[{"name":"Rob the Tester","email":"rob@test.com"}]}],"content":[{"type":"text/plain","value":"test email body"},{"type":"text/html","value":"test email body"}]}`,
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailService(zap.NewNop(), nil, client, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmail("test email", "test email body", "test email body",
+		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
+
+	assert.NoError(t, err)
+}
+
+func Test_SendEmail__should_return_error_when_sendgrid_rejects_request(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusUnauthorized,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailService(zap.NewNop(), nil, client, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmail("test email", "test email body", "test email body",
+		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
+
+	assert.Error(t, err)
+}
+
+func Test_SendEmailVerificationEmail__should_not_return_error_when_sending_email_is_successful(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailService(zap.NewNop(), &config.AppConfig{
+		Email: config.EmailConfig{
+			NoreplyEmailAddr:          "bob@test.com",
+			NoreplyEmailName:          "Bob the Tester",
+			EmailVerficationEmailSubj: "test subject",
+		},
+	}, client, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmailVerificationEmail(entities.User{
+		Name:  "Rob the Tester",
+		Email: "rob@test.com",
+	})
+	assert.NoError(t, err)
+}
+
+func Test_SendEmailVerificationEmailForUserWithEmail__should_make_correct_call_to_user_service(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	mockUService := mock_services.NewMockUserService(ctrl)
+	mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "bob@test.com").
+		Return(&entities.User{
+			Name:  "Bob the Tester",
+			Email: "bob@test.com",
+		}, nil).Times(1)
+
+	service, err := NewSendgridEmailService(zap.NewNop(), &config.AppConfig{
+		Email: config.EmailConfig{},
+	}, client, mockUService)
+	assert.NoError(t, err)
+
+	err = service.SendEmailVerificationEmailForUserWithEmail(context.Background(), "bob@test.com")
+	assert.NoError(t, err)
+}
+
+func Test_SendPasswordResetEmail__should_not_return_error_when_sending_email_is_successful(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailService(zap.NewNop(), &config.AppConfig{
+		Email: config.EmailConfig{
+			NoreplyEmailAddr:          "bob@test.com",
+			NoreplyEmailName:          "Bob the Tester",
+			EmailVerficationEmailSubj: "test subject",
+		},
+	}, client, nil)
+	assert.NoError(t, err)
+
+	err = service.SendPasswordResetEmail(entities.User{
+		Name:  "Rob the Tester",
+		Email: "rob@test.com",
+	})
+	assert.NoError(t, err)
+}
+
+func Test_SendPasswordResetEmailForUserWithEmail__should_make_correct_call_to_user_service(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	mockUService := mock_services.NewMockUserService(ctrl)
+	mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "bob@test.com").
+		Return(&entities.User{
+			Name:  "Bob the Tester",
+			Email: "bob@test.com",
+		}, nil).Times(1)
+
+	service, err := NewSendgridEmailService(zap.NewNop(), &config.AppConfig{
+		Email: config.EmailConfig{},
+	}, client, mockUService)
+	assert.NoError(t, err)
+
+	err = service.SendPasswordResetEmailForUserWithEmail(context.Background(), "bob@test.com")
+	assert.NoError(t, err)
+}
+
+func Test_SendEmailVerificationEmailForUserWithEmail__should_return_error_when_user_service_returns_error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockUService := mock_services.NewMockUserService(ctrl)
+	mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "bob@test.com").
+		Return(nil, services.ErrNotFound).Times(1)
+
+	service := &sendgridEmailService{
+		userService: mockUService,
+	}
+
+	err := service.SendEmailVerificationEmailForUserWithEmail(context.Background(), "bob@test.com")
+	assert.Equal(t, services.ErrNotFound, err)
+}
+
+func Test_SendPasswordResetEmailForUserWithEmail__should_return_error_when_user_service_returns_error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockUService := mock_services.NewMockUserService(ctrl)
+	mockUService.EXPECT().GetUserWithEmail(gomock.Any(), "bob@test.com").
+		Return(nil, services.ErrNotFound).Times(1)
+
+	service := &sendgridEmailService{
+		userService: mockUService,
+	}
+
+	err := service.SendPasswordResetEmailForUserWithEmail(context.Background(), "bob@test.com")
+	assert.Equal(t, services.ErrNotFound, err)
+}

--- a/services/sendgrid/testEmailTemplate.txt
+++ b/services/sendgrid/testEmailTemplate.txt
@@ -1,0 +1,1 @@
+{{.Link}} {{.SenderName}}

--- a/utils/template.go
+++ b/utils/template.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"html/template"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func LoadTemplate(templateName string, templatePath string) (*template.Template, error) {
+	file, err := os.Open(templatePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not open template file %s", templatePath)
+	}
+
+	templateStr, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not read template file %s", templatePath)
+	}
+
+	template, err := template.New(templateName).Parse(string(templateStr))
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse template %s", templateName)
+	}
+
+	return template, nil
+}


### PR DESCRIPTION
For issue #30

Implements a new email service client that includes more logic that was previously on the controller level.

`EmailServiceV2` will replace `EmailService` in the controllers in the future. I did not want to include these changes in this diff as it is already quite large

The new email service does not generate an email token when sending out an email currently. This is something that we'll need to figure out in #28 