### PR TITLE
Log user mistakes at Debug level

### DIFF
--- a/routers/api/v1/teams.go
+++ b/routers/api/v1/teams.go
@@ -40,7 +40,7 @@ func (r *apiV1Router) GetTeams(ctx *gin.Context) {
 func (r *apiV1Router) CreateTeam(ctx *gin.Context) {
 	name := ctx.PostForm("name")
 	if len(name) == 0 {
-		r.logger.Warn("team name not specified", zap.String("name", name))
+		r.logger.Debug("team name not specified", zap.String("name", name))
 		models.SendAPIError(ctx, http.StatusBadRequest, "request must include the team's name")
 		return
 	}
@@ -49,15 +49,15 @@ func (r *apiV1Router) CreateTeam(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidToken:
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 			break
 		case services.ErrNotFound:
-			r.logger.Warn("user not found")
+			r.logger.Debug("user not found")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user not found")
 			break
 		case services.ErrUserInTeam:
-			r.logger.Warn("user is already in a team")
+			r.logger.Debug("user is already in a team")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user is already in a team")
 			break
 		default:
@@ -85,15 +85,15 @@ func (r *apiV1Router) LeaveTeam(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidToken:
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 			break
 		case services.ErrNotFound:
-			r.logger.Warn("user or user's team not found")
+			r.logger.Debug("user or user's team not found")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user or user's team not found")
 			break
 		case services.ErrUserNotInTeam:
-			r.logger.Warn("user is not in a team")
+			r.logger.Debug("user is not in a team")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user is not in a team")
 			break
 		default:
@@ -116,7 +116,7 @@ func (r *apiV1Router) LeaveTeam(ctx *gin.Context) {
 func (r *apiV1Router) JoinTeam(ctx *gin.Context) {
 	team := ctx.Param("id")
 	if len(team) == 0 {
-		r.logger.Warn("team id not provided")
+		r.logger.Debug("team id not provided")
 		models.SendAPIError(ctx, http.StatusBadRequest, "team id must be provided")
 		return
 	}
@@ -125,19 +125,19 @@ func (r *apiV1Router) JoinTeam(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidToken:
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 			break
 		case services.ErrInvalidID:
-			r.logger.Warn("invalid team id")
+			r.logger.Debug("invalid team id")
 			models.SendAPIError(ctx, http.StatusBadRequest, "invalid auth id")
 			break
 		case services.ErrNotFound:
-			r.logger.Warn("team not found")
+			r.logger.Debug("team not found")
 			models.SendAPIError(ctx, http.StatusBadRequest, "team not found")
 			break
 		case services.ErrUserInTeam:
-			r.logger.Warn("user is already in a team")
+			r.logger.Debug("user is already in a team")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user is already in a team")
 			break
 		default:
@@ -161,7 +161,7 @@ func (r *apiV1Router) JoinTeam(ctx *gin.Context) {
 func (r *apiV1Router) GetTeamMembers(ctx *gin.Context) {
 	team := ctx.Param("id")
 	if len(team) == 0 {
-		r.logger.Warn("team id not provided")
+		r.logger.Debug("team id not provided")
 		models.SendAPIError(ctx, http.StatusBadRequest, "team id must be provided")
 		return
 	}
@@ -170,7 +170,7 @@ func (r *apiV1Router) GetTeamMembers(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidID:
-			r.logger.Warn("invalid team id")
+			r.logger.Debug("invalid team id")
 			models.SendAPIError(ctx, http.StatusBadRequest, "invalid team id provided")
 			break
 		default:

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -100,14 +100,14 @@ func (r *apiV1Router) UpdateUser(ctx *gin.Context) {
 func (r *apiV1Router) Login(ctx *gin.Context) {
 	email := ctx.PostForm("email")
 	if email == "" {
-		r.logger.Warn("email was not provided")
+		r.logger.Debug("email was not provided")
 		models.SendAPIError(ctx, http.StatusBadRequest, "email must be provided")
 		return
 	}
 
 	password := ctx.PostForm("password")
 	if password == "" {
-		r.logger.Warn("password was not provided")
+		r.logger.Debug("password was not provided")
 		models.SendAPIError(ctx, http.StatusBadRequest, "password must be provided")
 		return
 	}
@@ -115,7 +115,7 @@ func (r *apiV1Router) Login(ctx *gin.Context) {
 	user, err := r.userService.GetUserWithEmailAndPwd(ctx, email, password)
 	if err != nil {
 		if err == services.ErrNotFound {
-			r.logger.Warn("user not found", zap.String("email", email))
+			r.logger.Debug("user not found", zap.String("email", email))
 			models.SendAPIError(ctx, http.StatusUnauthorized, "user not found")
 		} else {
 			r.logger.Error("could not fetch user", zap.Error(err))
@@ -150,10 +150,10 @@ func (r *apiV1Router) GetMe(ctx *gin.Context) {
 	user, err := r.userService.GetUserWithJWT(ctx, ctx.GetHeader(authHeaderName))
 	if err != nil {
 		if err == services.ErrInvalidToken {
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 		} else if err == services.ErrNotFound {
-			r.logger.Warn("user not found")
+			r.logger.Debug("user not found")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user not found")
 		} else {
 			r.logger.Error("could not fetch user", zap.Error(err))
@@ -181,7 +181,7 @@ func (r *apiV1Router) PutMe(ctx *gin.Context) {
 	team := ctx.PostForm("team")
 
 	if len(name) == 0 && len(team) == 0 {
-		r.logger.Warn("neither name nor team provided")
+		r.logger.Debug("neither name nor team provided")
 		models.SendAPIError(ctx, http.StatusBadRequest, "either name or team must be provided")
 		return
 	}
@@ -195,11 +195,11 @@ func (r *apiV1Router) PutMe(ctx *gin.Context) {
 		_, err := r.teamService.GetTeamWithID(ctx, team)
 		if err != nil {
 			if err == services.ErrInvalidID {
-				r.logger.Warn("invalid team id", zap.String("id", team))
+				r.logger.Debug("invalid team id", zap.String("id", team))
 				models.SendAPIError(ctx, http.StatusBadRequest, "invalid team id")
 				return
 			} else if err == services.ErrNotFound {
-				r.logger.Warn("team with given id doesn't exist", zap.String("id", team))
+				r.logger.Debug("team with given id doesn't exist", zap.String("id", team))
 				models.SendAPIError(ctx, http.StatusBadRequest, "could not find team with given id")
 				return
 			} else {
@@ -214,7 +214,7 @@ func (r *apiV1Router) PutMe(ctx *gin.Context) {
 	err := r.userService.UpdateUserWithJWT(ctx, ctx.GetHeader(authHeaderName), fieldsToUpdate)
 	if err != nil {
 		if err == services.ErrInvalidToken {
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 		} else {
 			r.logger.Error("could not update user", zap.Any("fields to update", fieldsToUpdate), zap.Error(err))
@@ -241,14 +241,14 @@ func (r *apiV1Router) Register(ctx *gin.Context) {
 	password := ctx.PostForm("password")
 
 	if len(name) == 0 || len(email) == 0 || len(password) == 0 {
-		r.logger.Warn("one of name, email or password not specified", zap.String("name", name), zap.String("email", email), zap.Int("password length", len(password)))
+		r.logger.Debug("one of name, email or password not specified", zap.String("name", name), zap.String("email", email), zap.Int("password length", len(password)))
 		models.SendAPIError(ctx, http.StatusBadRequest, "request must include the user's name, email and passowrd")
 		return
 	}
 
 	user, err := r.userService.CreateUser(ctx, name, email, password)
 	if err == services.ErrEmailTaken {
-		r.logger.Warn("email taken", zap.String("email", email))
+		r.logger.Debug("email taken", zap.String("email", email))
 		models.SendAPIError(ctx, http.StatusBadRequest, "user with given email already exists")
 		return
 	} else if err != nil {
@@ -289,7 +289,7 @@ func (r *apiV1Router) VerifyEmail(ctx *gin.Context) {
 	err := r.userService.UpdateUserWithJWT(ctx, ctx.GetHeader(authHeaderName), fieldsToUpdate)
 	if err != nil {
 		if err == services.ErrInvalidToken {
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 		} else {
 			r.logger.Error("could not update user", zap.Any("fields to udpate", fieldsToUpdate))
@@ -310,7 +310,7 @@ func (r *apiV1Router) VerifyEmail(ctx *gin.Context) {
 func (r *apiV1Router) GetPasswordResetEmail(ctx *gin.Context) {
 	email := ctx.Query("email")
 	if len(email) == 0 {
-		r.logger.Warn("email not specified")
+		r.logger.Debug("email not specified")
 		models.SendAPIError(ctx, http.StatusBadRequest, "email must be specified")
 		return
 	}
@@ -336,14 +336,14 @@ func (r *apiV1Router) GetPasswordResetEmail(ctx *gin.Context) {
 func (r *apiV1Router) ResetPassword(ctx *gin.Context) {
 	email := ctx.Query("email")
 	if len(email) == 0 {
-		r.logger.Warn("email not specified")
+		r.logger.Debug("email not specified")
 		models.SendAPIError(ctx, http.StatusBadRequest, "email must be specified")
 		return
 	}
 
 	password := ctx.PostForm("password")
 	if len(password) == 0 {
-		r.logger.Warn("password not specified")
+		r.logger.Debug("password not specified")
 		models.SendAPIError(ctx, http.StatusBadRequest, "password must be specified")
 		return
 	}
@@ -351,7 +351,7 @@ func (r *apiV1Router) ResetPassword(ctx *gin.Context) {
 	err := r.userService.ResetPasswordForUserWithJWTAndEmail(ctx, ctx.GetHeader(authHeaderName), email, password)
 	if err != nil {
 		if err == services.ErrInvalidToken {
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 		}
 		r.logger.Error("could not set user's password", zap.Error(err))
@@ -374,19 +374,19 @@ func (r *apiV1Router) GetTeammates(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidToken:
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			models.SendAPIError(ctx, http.StatusUnauthorized, "invalid auth token")
 			break
 		case services.ErrInvalidID:
-			r.logger.Warn("invalid user id")
+			r.logger.Debug("invalid user id")
 			models.SendAPIError(ctx, http.StatusBadRequest, "invalid user id provided")
 			break
 		case services.ErrNotFound:
-			r.logger.Warn("user not found")
+			r.logger.Debug("user not found")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user not found")
 			break
 		case services.ErrUserNotInTeam:
-			r.logger.Warn("user is not in a team")
+			r.logger.Debug("user is not in a team")
 			models.SendAPIError(ctx, http.StatusBadRequest, "user is not in a team")
 			break
 		default:

--- a/routers/frontend/routes.go
+++ b/routers/frontend/routes.go
@@ -108,7 +108,7 @@ func (r *frontendRouter) Login(ctx *gin.Context) {
 	email := ctx.PostForm("email")
 	password := ctx.PostForm("password")
 	if email == "" || password == "" {
-		r.logger.Warn("email or password was not provided")
+		r.logger.Debug("email or password was not provided")
 		ctx.HTML(http.StatusBadRequest, "login.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "Both email and password are required",
@@ -119,7 +119,7 @@ func (r *frontendRouter) Login(ctx *gin.Context) {
 	user, err := r.userService.GetUserWithEmailAndPwd(ctx, email, password)
 	if err != nil {
 		if err == services.ErrNotFound {
-			r.logger.Warn("user not found", zap.String("email", email))
+			r.logger.Debug("user not found", zap.String("email", email))
 			ctx.HTML(http.StatusUnauthorized, "login.gohtml", templateDataModel{
 				Cfg: r.cfg,
 				Err: "User not found",
@@ -136,7 +136,7 @@ func (r *frontendRouter) Login(ctx *gin.Context) {
 
 	// TODO: should allow the user to resend verification email
 	if !user.EmailVerified {
-		r.logger.Warn("user's email not verified", zap.String("user id", user.ID.Hex()), zap.String("email", email))
+		r.logger.Debug("user's email not verified", zap.String("user id", user.ID.Hex()), zap.String("email", email))
 		ctx.HTML(http.StatusUnauthorized, "login.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "User's email not verified",
@@ -176,7 +176,7 @@ func (r *frontendRouter) Register(ctx *gin.Context) {
 	passwordConfirm := ctx.PostForm("passwordConfirm")
 
 	if len(name) == 0 || len(email) == 0 || len(password) == 0 {
-		r.logger.Warn("one of name, email, password, passwordConfirm not specified", zap.String("name", name), zap.String("email", email), zap.Int("password length", len(password)), zap.Int("passwordConfirm length", len(passwordConfirm)))
+		r.logger.Debug("one of name, email, password, passwordConfirm not specified", zap.String("name", name), zap.String("email", email), zap.Int("password length", len(password)), zap.Int("passwordConfirm length", len(passwordConfirm)))
 		ctx.HTML(http.StatusBadRequest, "register.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "All fields are required",
@@ -186,7 +186,7 @@ func (r *frontendRouter) Register(ctx *gin.Context) {
 
 	// TODO: might be a good idea to handle this at the service level
 	if len(password) < 6 || len(password) > 160 {
-		r.logger.Warn("invalid password length", zap.Int("length", len(password)))
+		r.logger.Debug("invalid password length", zap.Int("length", len(password)))
 		ctx.HTML(http.StatusBadRequest, "register.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "Password must contain between 6 and 160 characters",
@@ -195,7 +195,7 @@ func (r *frontendRouter) Register(ctx *gin.Context) {
 	}
 
 	if password != passwordConfirm {
-		r.logger.Warn("password and passwordConfirm do not match")
+		r.logger.Debug("password and passwordConfirm do not match")
 		ctx.HTML(http.StatusBadRequest, "register.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "Passwords do not match",
@@ -207,7 +207,7 @@ func (r *frontendRouter) Register(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrEmailTaken:
-			r.logger.Warn("email taken")
+			r.logger.Debug("email taken")
 			ctx.HTML(http.StatusBadRequest, "register.gohtml", templateDataModel{
 				Cfg: r.cfg,
 				Err: "Email taken",
@@ -249,7 +249,7 @@ func (r *frontendRouter) ForgotPassword(ctx *gin.Context) {
 	email := ctx.PostForm("email")
 
 	if len(email) == 0 {
-		r.logger.Warn("email not specified")
+		r.logger.Debug("email not specified")
 		ctx.HTML(http.StatusBadRequest, "forgotPassword.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "Please enter your email",
@@ -264,7 +264,7 @@ func (r *frontendRouter) ForgotPassword(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrNotFound:
-			r.logger.Warn("user with email doesn't exist", zap.String("email", email))
+			r.logger.Debug("user with email doesn't exist", zap.String("email", email))
 			// don't want to give the user a tool to figure which email addresses are registered
 			// as this would be a security issue
 			ctx.HTML(http.StatusOK, "forgotPasswordEnd.gohtml", templateDataModel{
@@ -321,7 +321,7 @@ func (r *frontendRouter) ResetPassword(ctx *gin.Context) {
 	}
 
 	if len(email) == 0 || len(password) == 0 || len(passwordConfirm) == 0 {
-		r.logger.Warn("one of email, password, passwordConfirm not specified", zap.String("email", email), zap.Int("password len", len(password)), zap.Int("passwordConfirm len", len(passwordConfirm)))
+		r.logger.Debug("one of email, password, passwordConfirm not specified", zap.String("email", email), zap.Int("password len", len(password)), zap.Int("passwordConfirm len", len(passwordConfirm)))
 		ctx.HTML(http.StatusBadRequest, "resetPassword.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "All fields are required",
@@ -334,7 +334,7 @@ func (r *frontendRouter) ResetPassword(ctx *gin.Context) {
 	}
 
 	if password != passwordConfirm {
-		r.logger.Warn("password and passwordConfirm do not match")
+		r.logger.Debug("password and passwordConfirm do not match")
 		ctx.HTML(http.StatusBadRequest, "resetPassword.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "Passwords do not match",
@@ -366,7 +366,7 @@ func (r *frontendRouter) ResetPassword(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidToken:
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			ctx.HTML(http.StatusUnauthorized, "resetPassword.gohtml", templateDataModel{
 				Cfg: r.cfg,
 				Err: "Invalid token",
@@ -377,7 +377,7 @@ func (r *frontendRouter) ResetPassword(ctx *gin.Context) {
 			})
 			return
 		case services.ErrNotFound:
-			r.logger.Warn("could not find user with token")
+			r.logger.Debug("could not find user with token")
 			ctx.HTML(http.StatusUnauthorized, "resetPassword.gohtml", templateDataModel{
 				Cfg: r.cfg,
 				Err: "Could not find user with given auth token",
@@ -409,7 +409,7 @@ func (r *frontendRouter) ResetPassword(ctx *gin.Context) {
 func (r *frontendRouter) VerifyEmail(ctx *gin.Context) {
 	token := ctx.Query("token")
 	if token == "" {
-		r.logger.Warn("empty token")
+		r.logger.Debug("empty token")
 		ctx.HTML(http.StatusUnauthorized, "login.gohtml", templateDataModel{
 			Cfg: r.cfg,
 			Err: "Invalid token",
@@ -423,14 +423,14 @@ func (r *frontendRouter) VerifyEmail(ctx *gin.Context) {
 	if err != nil {
 		switch err {
 		case services.ErrInvalidToken:
-			r.logger.Warn("invalid token")
+			r.logger.Debug("invalid token")
 			ctx.HTML(http.StatusUnauthorized, "login.gohtml", templateDataModel{
 				Cfg: r.cfg,
 				Err: "Invalid token",
 			})
 			return
 		case services.ErrNotFound:
-			r.logger.Warn("could not find user with token")
+			r.logger.Debug("could not find user with token")
 			ctx.HTML(http.StatusUnauthorized, "resetPassword.gohtml", templateDataModel{
 				Cfg: r.cfg,
 				Err: "Couldn't find user with given auth token",
@@ -468,7 +468,7 @@ func (r *frontendRouter) CreateTeam(ctx *gin.Context) {
 
 	name := ctx.PostForm("name")
 	if len(name) == 0 {
-		r.logger.Warn("team name not specified", zap.String("name", name))
+		r.logger.Debug("team name not specified", zap.String("name", name))
 		r.renderProfilePage(ctx, http.StatusBadRequest, "Please specify team name")
 		return
 	}
@@ -504,7 +504,7 @@ func (r *frontendRouter) JoinTeam(ctx *gin.Context) {
 
 	team := ctx.PostForm("id")
 	if len(team) == 0 {
-		r.logger.Warn("team id not provided")
+		r.logger.Debug("team id not provided")
 		r.renderProfilePage(ctx, http.StatusBadRequest, "Please specify the ID of the team to join")
 		return
 	}
@@ -517,11 +517,11 @@ func (r *frontendRouter) JoinTeam(ctx *gin.Context) {
 			ctx.Redirect(http.StatusSeeOther, "/login")
 			return
 		case services.ErrNotFound:
-			r.logger.Warn("team with id not found")
+			r.logger.Debug("team with id not found")
 			r.renderProfilePage(ctx, http.StatusBadRequest, "Team with given ID does not exist")
 			return
 		case services.ErrUserInTeam:
-			r.logger.Warn("user already in team")
+			r.logger.Debug("user already in team")
 			r.renderProfilePage(ctx, http.StatusBadRequest, "You are already in a team")
 			return
 		default:
@@ -550,11 +550,11 @@ func (r *frontendRouter) LeaveTeam(ctx *gin.Context) {
 			ctx.Redirect(http.StatusSeeOther, "/login")
 			return
 		case services.ErrNotFound:
-			r.logger.Warn("user in token not found")
+			r.logger.Debug("user in token not found")
 			r.renderProfilePage(ctx, http.StatusBadRequest, "Invalid auth token")
 			return
 		case services.ErrUserNotInTeam:
-			r.logger.Warn("user is not in team")
+			r.logger.Debug("user is not in team")
 			r.renderProfilePage(ctx, http.StatusBadRequest, "You are not in a team")
 			return
 		default:


### PR DESCRIPTION
Reduces the log level used for logging user mistakes (invalid parameters for requests, unauthorized requests etc.) from Warn to Debug.

I wanted to standardize how we log information in the app and tried to enforce a pattern that I see being used quite frequently:
- Error level is used for problems that are degrading the user experience
- Warn level is used for problems that might cause a degrading effect on the user experience in the future
- Info level is used for logging one-time events, or at least when the number of times the event gets logged does not depend on the number of requests received (O(1) in terms of the number of requests received)
- Debug level is used for logging problems that do not degrade the user experience (e.g.: errors caused by invalid input) and any other information that does not fall into the other categories.

This should hopefully make it easier to identify issues in the future as we'll be able to search the logs more efficiently.