### PR TITLE
Implement string based auth levels for JSON responses

### DIFF
--- a/entities/user_test.go
+++ b/entities/user_test.go
@@ -2,6 +2,7 @@ package entities
 
 import (
 	"encoding/json"
+	"github.com/unicsmcr/hs_auth/utils/auth/common"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,3 +24,21 @@ func Test_Password__should_be_ommitted_when_marshalling_user_to_JSON(t *testing.
 
 	assert.Empty(t, unmarshalledUser.Password)
 }
+
+func Test_AuthLevel__should_be_converted_to_string_when_marshalling_user_to_JSON(t *testing.T) {
+	user := User{
+		AuthLevel: common.Organiser,
+	}
+
+	userJSON, err := json.Marshal(user)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(userJSON), "\"auth_level\":\"organiser\"")
+
+	var unmarshalledUser User
+	err = json.Unmarshal(userJSON, &unmarshalledUser)
+	assert.NoError(t, err)
+
+	assert.Equal(t, common.Organiser, unmarshalledUser.AuthLevel)
+}
+

--- a/routers/api/v1/router.go
+++ b/routers/api/v1/router.go
@@ -78,7 +78,8 @@ func (r apiV1Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	usersGroup.GET("/", isAtLeastOrganizer, r.GetUsers)
 	// TODO: this endpoint cannot be accesible through PUT:/:id as PUT:/:id would conflict with PUT:/me
 	//       Moving PUT:/me to a different endpoint would introduce breaking changes to the service's consumers
-	usersGroup.PUT("/update/:id", isAtLeastOrganizer, r.UpdateUser)
+	// TODO: UpdateUser does not have input validation and is unsafe to use
+	//usersGroup.PUT("/update/:id", isAtLeastOrganizer, r.UpdateUser)
 	usersGroup.POST("/", r.Register)
 	usersGroup.POST("/login", r.Login)
 	usersGroup.POST("/email/verify", r.VerifyEmail)

--- a/routers/api/v1/router.go
+++ b/routers/api/v1/router.go
@@ -72,7 +72,7 @@ func (r apiV1Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	routerGroup.GET("/", r.Heartbeat)
 
 	isAtLeastApplicant := auth.AuthLevelVerifierFactory(authlevels.Applicant, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
-	isAtLeastOrganizer := auth.AuthLevelVerifierFactory(authlevels.Organizer, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
+	isAtLeastOrganizer := auth.AuthLevelVerifierFactory(authlevels.Organiser, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
 
 	usersGroup := routerGroup.Group("/users")
 	usersGroup.GET("/", isAtLeastOrganizer, r.GetUsers)

--- a/routers/api/v1/router.go
+++ b/routers/api/v1/router.go
@@ -72,14 +72,14 @@ func (r apiV1Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	routerGroup.GET("/", r.Heartbeat)
 
 	isAtLeastApplicant := auth.AuthLevelVerifierFactory(authlevels.Applicant, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
-	isAtLeastOrganizer := auth.AuthLevelVerifierFactory(authlevels.Organiser, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
+	isAtLeastOrganiser := auth.AuthLevelVerifierFactory(authlevels.Organiser, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
 
 	usersGroup := routerGroup.Group("/users")
-	usersGroup.GET("/", isAtLeastOrganizer, r.GetUsers)
+	usersGroup.GET("/", isAtLeastOrganiser, r.GetUsers)
 	// TODO: this endpoint cannot be accesible through PUT:/:id as PUT:/:id would conflict with PUT:/me
 	//       Moving PUT:/me to a different endpoint would introduce breaking changes to the service's consumers
 	// TODO: UpdateUser does not have input validation and is unsafe to use
-	//usersGroup.PUT("/update/:id", isAtLeastOrganizer, r.UpdateUser)
+	//usersGroup.PUT("/update/:id", isAtLeastOrganiser, r.UpdateUser)
 	usersGroup.POST("/", r.Register)
 	usersGroup.POST("/login", r.Login)
 	usersGroup.POST("/email/verify", r.VerifyEmail)
@@ -92,9 +92,9 @@ func (r apiV1Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	usersGroup.GET("/teammates", isAtLeastApplicant, r.GetTeammates)
 
 	teamsGroup := routerGroup.Group("/teams")
-	teamsGroup.GET("/", isAtLeastOrganizer, r.GetTeams)
+	teamsGroup.GET("/", isAtLeastOrganiser, r.GetTeams)
 	teamsGroup.POST("/", isAtLeastApplicant, r.CreateTeam)
-	teamsGroup.GET("/:id/members", isAtLeastOrganizer, r.GetTeamMembers)
+	teamsGroup.GET("/:id/members", isAtLeastOrganiser, r.GetTeamMembers)
 	teamsGroup.POST("/:id/join", isAtLeastApplicant, r.JoinTeam)
 	teamsGroup.DELETE("/leave", isAtLeastApplicant, r.LeaveTeam)
 }

--- a/routers/api/v1/router_test.go
+++ b/routers/api/v1/router_test.go
@@ -157,7 +157,7 @@ func Test_RegisterRoutes__should_set_up_required_auth_verification(t *testing.T)
 		{
 			route:        "/users/",
 			method:       http.MethodGet,
-			minAuthLevel: authlevels.Organizer,
+			minAuthLevel: authlevels.Organiser,
 		},
 		{
 			route:        "/users/me",
@@ -183,7 +183,7 @@ func Test_RegisterRoutes__should_set_up_required_auth_verification(t *testing.T)
 		{
 			route:        "/teams/",
 			method:       http.MethodGet,
-			minAuthLevel: authlevels.Organizer,
+			minAuthLevel: authlevels.Organiser,
 		},
 		{
 			route:        "/teams/",
@@ -203,7 +203,7 @@ func Test_RegisterRoutes__should_set_up_required_auth_verification(t *testing.T)
 		{
 			route:        "/teams/123abd/members",
 			method:       http.MethodGet,
-			minAuthLevel: authlevels.Organizer,
+			minAuthLevel: authlevels.Organiser,
 		},
 	}
 

--- a/routers/api/v1/router_test.go
+++ b/routers/api/v1/router_test.go
@@ -54,10 +54,11 @@ func Test_RegisterRoutes__should_register_required_routes(t *testing.T) {
 			route:  "/users/login",
 			method: http.MethodPost,
 		},
-		{
-			route:  "/users/update/123",
-			method: http.MethodPut,
-		},
+		// TODO: re-enable when endpoint is fixed
+		//{
+		//	route:  "/users/update/123",
+		//	method: http.MethodPut,
+		//},
 		{
 			route:  "/users/me",
 			method: http.MethodGet,
@@ -173,11 +174,12 @@ func Test_RegisterRoutes__should_set_up_required_auth_verification(t *testing.T)
 			method:       http.MethodPut,
 			minAuthLevel: authlevels.Applicant,
 		},
-		{
-			route:        "/users/update/123",
-			method:       http.MethodPut,
-			minAuthLevel: authlevels.Organizer,
-		},
+		// TODO: re-enable when endpoint is fixed
+		//{
+		//	route:        "/users/update/123",
+		//	method:       http.MethodPut,
+		//	minAuthLevel: authlevels.Organizer,
+		//},
 		{
 			route:        "/teams/",
 			method:       http.MethodGet,

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -51,7 +51,7 @@ func (r *apiV1Router) UpdateUser(ctx *gin.Context) {
 	var updatedFields services.UserUpdateParams
 	err := json.Unmarshal([]byte(ctx.PostForm("set")), &updatedFields)
 	if err != nil {
-		r.logger.Debug("could not unmarshall field 'set' to var of type map[entities.UserField]interface{}", zap.Error(err))
+		r.logger.Debug("could not unmarshall field 'set' to var of type services.UserUpdateParams", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusBadRequest, "invalid value of field 'set'")
 		return
 	}

--- a/routers/frontend/router.go
+++ b/routers/frontend/router.go
@@ -76,7 +76,7 @@ func NewRouter(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env, 
 }
 
 func (r *frontendRouter) RegisterRoutes(routerGroup *gin.RouterGroup) {
-	isAtLeastOrganizer := auth.AuthLevelVerifierFactory(authlevels.Organizer, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
+	isAtLeastOrganiser := auth.AuthLevelVerifierFactory(authlevels.Organiser, jwtProvider, []byte(r.env.Get(environment.JWTSecret)), invalidJWTHandler)
 
 	routerGroup.GET("", r.ProfilePage)
 	routerGroup.GET("login", r.LoginPage)
@@ -92,5 +92,5 @@ func (r *frontendRouter) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	routerGroup.POST("team/create", r.CreateTeam)
 	routerGroup.POST("team/join", r.JoinTeam)
 	routerGroup.POST("team/leave", r.LeaveTeam)
-	routerGroup.POST("user/update/:id", isAtLeastOrganizer, r.UpdateUser)
+	routerGroup.POST("user/update/:id", isAtLeastOrganiser, r.UpdateUser)
 }

--- a/routers/frontend/routes.go
+++ b/routers/frontend/routes.go
@@ -73,7 +73,7 @@ func (r *frontendRouter) getProfilePageData(ctx *gin.Context, jwt string) (profi
 		return profilePageData{}, err
 	}
 
-	if data.User.AuthLevel >= authlevels.Organizer {
+	if data.User.AuthLevel >= authlevels.Organiser {
 		users, err := r.userService.GetUsers(ctx)
 		if err != nil {
 			r.logger.Error("could not get users", zap.Error(err))

--- a/routers/frontend/routes_test.go
+++ b/routers/frontend/routes_test.go
@@ -299,28 +299,28 @@ func Test_getProfilePageData(t *testing.T) {
 			},
 		},
 		{
-			name: "should return the user and an empty AdminData when user is Organizer and GetUsers returns err",
+			name: "should return the user and an empty AdminData when user is Organiser and GetUsers returns err",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
-					Return(&entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organizer}, nil).Times(1)
+					Return(&entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organiser}, nil).Times(1)
 				setup.mockUService.EXPECT().GetUsers(gomock.Any()).
 					Return(nil, errors.New("service err")).Times(1)
 			},
 			wantOut: profilePageData{
-				User:      &entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organizer},
+				User:      &entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organiser},
 				AdminData: adminData{},
 			},
 		},
 		{
-			name: "should include all users in AdminData when user is an Organizer",
+			name: "should include all users in AdminData when user is an Organiser",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
-					Return(&entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organizer}, nil).Times(1)
+					Return(&entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organiser}, nil).Times(1)
 				setup.mockUService.EXPECT().GetUsers(gomock.Any()).
 					Return([]entities.User{{Name: "Bob the Tester"}, {Name: "Rob the Tester"}}, nil).Times(1)
 			},
 			wantOut: profilePageData{
-				User: &entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organizer},
+				User: &entities.User{ID: userID, Name: "Bob the Tester", AuthLevel: common.Organiser},
 				AdminData: adminData{
 					Users: []entities.User{{Name: "Bob the Tester"}, {Name: "Rob the Tester"}},
 				},

--- a/services/errors.go
+++ b/services/errors.go
@@ -14,9 +14,10 @@ var (
 	ErrSendgridRejectedRequest = errors.New("email request rejected by Sendgrid")
 
 	// User service errors
-	ErrEmailTaken   = errors.New("email is already taken")
-	ErrNameTaken    = errors.New("name is already taken")
-	ErrInvalidToken = errors.New("invalid auth token")
+	ErrEmailTaken              = errors.New("email is already taken")
+	ErrNameTaken               = errors.New("name is already taken")
+	ErrInvalidToken            = errors.New("invalid auth token")
+	ErrInvalidUserUpdateParams = errors.New("invlid user update params")
 
 	// Team service errors
 	ErrUserInTeam    = errors.New("user is already in a team")

--- a/services/userService.go
+++ b/services/userService.go
@@ -2,10 +2,36 @@ package services
 
 import (
 	"context"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"strconv"
 
 	"github.com/unicsmcr/hs_auth/entities"
 	authlevels "github.com/unicsmcr/hs_auth/utils/auth/common"
 )
+
+func BuildUserUpdateParams(stringParams map[entities.UserField]string) (builtParams UserUpdateParams, err error) {
+	builtParams = UserUpdateParams{}
+	for field, value := range stringParams {
+		switch field {
+		case entities.UserID, entities.UserTeam:
+			builtParams[field], err = primitive.ObjectIDFromHex(value)
+			if err != nil {
+				return UserUpdateParams{}, ErrInvalidUserUpdateParams
+			}
+			break
+		case entities.UserName, entities.UserEmail, entities.UserPassword:
+			builtParams[field] = value
+			break
+		case entities.UserAuthLevel:
+			builtParams[field], err = strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return UserUpdateParams{}, ErrInvalidUserUpdateParams
+			}
+			break
+		}
+	}
+	return builtParams, nil
+}
 
 type UserUpdateParams map[entities.UserField]interface{}
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2,15 +2,41 @@ var table = new Tabulator("#users-list", {
     height: "70%",
     data: adminData != null && adminData.hasOwnProperty("users") ? adminData.users : [],
     layout: "fitColumns",
-    pagination:"local",
-    paginationSize:20,
-    paginationSizeSelector:[20, 50, 100, 1000],
-    movableColumns:true,
+    pagination: "local",
+    paginationSize: 20,
+    paginationSizeSelector: [20, 50, 100, 1000],
+    movableColumns: true,
     index: "_id",
+    cellEdited: updateUser,
     columns: [
-        { title: "Name", field: "name", headerFilter: "input" },
+        { title: "Name", field: "name", headerFilter: "input", editor: "input" },
         { title: "Email", field: "email", headerFilter: "input" },
-        { title: "Auth Level", field: "auth_level", headerFilter:"number", headerFilterPlaceholder:"at least...", headerFilterFunc:">="},
-        { title: "Team", field: "team", headerFilter:"input"},
+        { title: "Auth Level", field: "auth_level", headerFilter: "number", headerFilterPlaceholder: "at least...", headerFilterFunc: ">=", editor: "number" },
+        { title: "Team", field: "team", headerFilter: "input", editor: "input" },
     ]
 });
+
+function updateUser(cell) {
+    var field = cell._cell.column.field
+    var updatedValue = cell._cell.value
+    var oldValue = cell._cell.oldValue
+    var user = cell._cell.row.data
+
+    var input = confirm("About to update user " + user.name + "(" + user.email + ")\n" +
+        "Will change field " + field + ":\n" +
+        oldValue + " -> " + updatedValue + "\n" +
+        "Continue?")
+    if (input === false) { // cancel changes
+        // reload to clear local changes
+        location.reload()
+        return
+    }
+
+    $.ajax({
+        type: "POST",
+        url: "/user/update/" + user._id,
+        data: "set={\"" + field + "\":\"" + updatedValue + "\"}",
+        success: location.reload,
+        dataType: "text"
+    });
+}

--- a/utils/auth/auth_test.go
+++ b/utils/auth/auth_test.go
@@ -168,8 +168,8 @@ func Test_AuthLevelVerifierFactory__should_return_middleware(t *testing.T) {
 		},
 		{
 			name:           "that calls next handler when auth level is above required",
-			givenAuthLevel: 4,
-			wantAuthLevel:  3,
+			givenAuthLevel: 3,
+			wantAuthLevel:  2,
 			wantNextCalled: true,
 		},
 	}

--- a/utils/auth/common/authLevel.go
+++ b/utils/auth/common/authLevel.go
@@ -1,5 +1,9 @@
 package common
 
+import (
+	"errors"
+)
+
 // AuthLevel is a type for storing a users auth level
 type AuthLevel int
 
@@ -10,6 +14,34 @@ const (
 	Attendee
 	// Volunteer is the auth level that represents a user who has access to volunteer features
 	Volunteer
-	// Organizer is the auth level that represents a user who has access to all features
-	Organizer
+	// Organiser is the auth level that represents a user who has access to all features
+	Organiser
 )
+
+var ErrUnknownAuthLevel = errors.New("auth level unknown")
+
+// string representation of the auth levels.
+// used when sending an AuthLevel in a JSON response
+var stringAuthLevels = map[AuthLevel]string{
+	Applicant: "\"applicant\"",
+	Attendee:  "\"attendee\"",
+	Volunteer: "\"volunteer\"",
+	Organiser: "\"organiser\"",
+}
+
+func (al AuthLevel) MarshalJSON() ([]byte, error) {
+	if lvl, ok := stringAuthLevels[al]; ok {
+		return []byte(lvl), nil
+	}
+	return nil, ErrUnknownAuthLevel
+}
+
+func (al *AuthLevel) UnmarshalJSON(data []byte) error {
+	for lvl, stringLvl := range stringAuthLevels {
+		if stringLvl == string(data) {
+			*al = lvl
+			return nil
+		}
+	}
+	return ErrUnknownAuthLevel
+}

--- a/utils/auth/common/authLevel_test.go
+++ b/utils/auth/common/authLevel_test.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_MarshalJSON__should_return_correct_string_for_each_auth_level(t *testing.T) {
+	tests := []struct{
+		name string
+		authLvl AuthLevel
+		expectedResult string
+	}{
+		{
+			name: "applicant",
+			authLvl:Applicant,
+			expectedResult:"\"applicant\"",
+		},
+		{
+			name: "attendee",
+			authLvl:Attendee,
+			expectedResult:"\"attendee\"",
+		},
+		{
+			name: "volunteer",
+			authLvl:Volunteer,
+			expectedResult:"\"volunteer\"",
+		},
+		{
+			name: "organiser",
+			authLvl:Organiser,
+			expectedResult:"\"organiser\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.authLvl.MarshalJSON()
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expectedResult, string(result))
+		})
+	}
+}
+
+func Test_MarshalJSON__should_return_ErrUnknownAuthLevel_for_unregistered_auth_level(t *testing.T) {
+	fakeAuthLvl := AuthLevel(9000)
+
+	stringLvl, err := fakeAuthLvl.MarshalJSON()
+
+	assert.Error(t, err)
+	assert.Nil(t, stringLvl)
+}
+
+
+func Test_UnmarshalJSON__should_return_correct_auth_levels_for_registered_auth_level_strings(t *testing.T) {
+	tests := []struct{
+		name string
+		stringAuthLvl string
+		expectedAuthLvl AuthLevel
+	}{
+		{
+			name: "applicant",
+			stringAuthLvl:"\"applicant\"",
+			expectedAuthLvl:Applicant,
+		},
+		{
+			name: "attendee",
+			stringAuthLvl:"\"attendee\"",
+			expectedAuthLvl:Attendee,
+		},
+		{
+			name: "volunteer",
+			stringAuthLvl:"\"volunteer\"",
+			expectedAuthLvl:Volunteer,
+		},
+		{
+			name: "organiser",
+			stringAuthLvl:"\"organiser\"",
+			expectedAuthLvl:Organiser,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var testAuthLvl AuthLevel
+			err := testAuthLvl.UnmarshalJSON([]byte(tt.stringAuthLvl))
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expectedAuthLvl, testAuthLvl)
+		})
+	}
+}
+
+
+func Test_UnmarshalJSON__should_return_ErrUnknownAuthLevel_for_unregistered_auth_level(t *testing.T) {
+	var testAuthLvl AuthLevel
+
+	err := testAuthLvl.UnmarshalJSON([]byte("unregistered auth level"))
+
+	assert.Error(t, err)
+	assert.Zero(t, testAuthLvl)
+}


### PR DESCRIPTION
For issue #28 

Implements string based auth level for JSON responses. String auth levels are only used when sending a response in JSON, internally the app still uses ints as it is much safer to compare ints than strings.

Also renames the auth level `Organizer` to `Organiser` because we're not 'murican. 