### PR TITLE
Email verify resend

### DIFF
--- a/routers/frontend/router_test.go
+++ b/routers/frontend/router_test.go
@@ -74,6 +74,14 @@ func Test_RegisterRoutes__should_register_required_routes(t *testing.T) {
 			method: http.MethodGet,
 		},
 		{
+			route:  "/verifyemail/resend",
+			method: http.MethodGet,
+		},
+		{
+			route:  "/emailunverified",
+			method: http.MethodGet,
+		},
+		{
 			route:  "/team/create",
 			method: http.MethodPost,
 		},

--- a/routers/frontend/routes_test.go
+++ b/routers/frontend/routes_test.go
@@ -141,14 +141,14 @@ func Test_Login(t *testing.T) {
 			wantResCode: http.StatusInternalServerError,
 		},
 		{
-			name:     "should return 401 when user's email is not verified",
+			name:     "should return 200 when user's email is not verified",
 			email:    "test@email.com",
 			password: "testpassword",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithEmailAndPwd(gomock.Any(), "test@email.com", "testpassword").
 					Return(&entities.User{AuthLevel: common.Unverified}, nil).Times(1)
 			},
-			wantResCode: http.StatusUnauthorized,
+			wantResCode: http.StatusOK,
 		},
 		{
 			name:     "should return 200",
@@ -1068,6 +1068,96 @@ func Test_UpdateUser(t *testing.T) {
 			})
 
 			setup.router.UpdateUser(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+		})
+	}
+}
+
+func Test_VerifyEmailResend(t *testing.T) {
+	tests := []struct {
+		name        string
+		prep        func(*testSetup)
+		jwt         string
+		wantResCode int
+	}{
+		{
+			name: "should return 401 when GetUserWithJWT returns ErrInvalidToken",
+			jwt:  "test",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
+					Return(nil, services.ErrInvalidToken)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name: "should return 400 when GetUserWithJWT returns ErrNotFound",
+			jwt:  "test",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
+					Return(nil, services.ErrNotFound)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name: "should return 500 when GetUserWithJWT returns unknown error",
+			jwt:  "test",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
+					Return(nil, errors.New("service err"))
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name: "should return 500 when SendEmailVerificationEmail returns error",
+			jwt:  "test",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
+					Return(&entities.User{}, nil)
+				setup.mockEService.EXPECT().SendEmailVerificationEmail(gomock.Any()).
+					Return(errors.New("service err"))
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name: "should return 200 when SendEmailVerificationEmail returns nil",
+			jwt:  "test",
+			prep: func(setup *testSetup) {
+				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test").
+					Return(&entities.User{}, nil)
+				setup.mockEService.EXPECT().SendEmailVerificationEmail(gomock.Any()).
+					Return(nil)
+			},
+			wantResCode: http.StatusOK,
+		},
+		//{
+		//	name: "should return 200",
+		//	jwt:  "test",
+		//	prep: func(setup *testSetup) {
+		//		setup.mockTService.EXPECT().RemoveUserWithJWTFromTheirTeam(gomock.Any(), "test").
+		//			Return(nil)
+		//	},
+		//	wantResCode: http.StatusOK,
+		//},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupTest(t, map[string]string{
+				environment.JWTSecret: "test",
+			}, 0)
+
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodPost, map[string]string{})
+			setup.testCtx.Request.AddCookie(&http.Cookie{
+				Name:  authCookieName,
+				Value: tt.jwt,
+			})
+
+			setup.router.VerifyEmailResend(setup.testCtx)
 
 			assert.Equal(t, tt.wantResCode, setup.w.Code)
 		})

--- a/routers/frontend/routes_test.go
+++ b/routers/frontend/routes_test.go
@@ -1130,15 +1130,6 @@ func Test_VerifyEmailResend(t *testing.T) {
 			},
 			wantResCode: http.StatusOK,
 		},
-		//{
-		//	name: "should return 200",
-		//	jwt:  "test",
-		//	prep: func(setup *testSetup) {
-		//		setup.mockTService.EXPECT().RemoveUserWithJWTFromTheirTeam(gomock.Any(), "test").
-		//			Return(nil)
-		//	},
-		//	wantResCode: http.StatusOK,
-		//},
 	}
 
 	for _, tt := range tests {

--- a/templates/emails/emailVerify_email.gohtml
+++ b/templates/emails/emailVerify_email.gohtml
@@ -1,4 +1,4 @@
-pass<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml">
 <head>
@@ -145,7 +145,7 @@ pass<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Click this link to verify your email:</p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
-<p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">{{.VerficationLink}}</p>
+<p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">{{.Link}}</p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Thanks!</p>

--- a/templates/pages/emailNotVerified.gohtml
+++ b/templates/pages/emailNotVerified.gohtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  {{template "header.gohtml" .Cfg}}
+  <link rel="stylesheet" type="text/css" href="/static/css/login.css">
+</head>
+
+<body>
+  <div class="container">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="card mx-auto align-middle w-50">
+          <div class="card-header card-header-primary">
+            <h2>Email not verified!</h2>
+          </div>
+          <div class="card-body">
+            <h2>Oops!</h2>
+            <h4>It looks like you have not yet verified your email!</h4>
+            <h4>Look for an email with a verification link in your email box.</h4>
+            <h4>Or click <a href="/verifyemail/resend">here</a> to resend the email.</h4>
+            </h6>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+{{if .Err}}
+{{template "errorNotifier.gohtml" .Err}}
+{{end}}
+{{template "cookieDisclaimer.gohtml"}}
+</html>

--- a/templates/pages/emailVerifyResend.gohtml
+++ b/templates/pages/emailVerifyResend.gohtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  {{template "header.gohtml" .Cfg}}
+  <link rel="stylesheet" type="text/css" href="/static/css/login.css">
+</head>
+
+<body>
+  <div class="container">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="card mx-auto align-middle w-50">
+          <div class="card-header card-header-primary">
+            <h2>Verification email sent!</h2>
+          </div>
+          <div class="card-body">
+            <h2>Success!</h2>
+            <h4>A new verification email has been sent to your email address!</h4>
+            <h6>Check your spam folder if you can't find the email and if it's not there,
+            drop us a message at <a href="mailto:{{.Cfg.Email.HelpEmailAddr}}?Subject=Can't%20verify%20email" target="_top">{{.Cfg.Email.HelpEmailAddr}}</a>
+            </h6>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+{{if .Err}}
+{{template "errorNotifier.gohtml" .Err}}
+{{end}}
+{{template "cookieDisclaimer.gohtml"}}
+</html>

--- a/templates/pages/verificationTokenInvalid.gohtml
+++ b/templates/pages/verificationTokenInvalid.gohtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  {{template "header.gohtml" .Cfg}}
+  <link rel="stylesheet" type="text/css" href="/static/css/login.css">
+</head>
+
+<body>
+  <div class="container">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="card mx-auto align-middle w-50">
+          <div class="card-header card-header-primary">
+            <h2>Invalid token!</h2>
+          </div>
+          <div class="card-body">
+            <h2>Oops!</h2>
+            <h4>It looks like your verification token is invalid! It might have expired.</h4>
+            <h4>You can get a new token by <a href="/login">logging in</a> and requesting a new verification email.</h4>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+{{if .Err}}
+{{template "errorNotifier.gohtml" .Err}}
+{{end}}
+{{template "cookieDisclaimer.gohtml"}}
+</html>

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -39,7 +39,7 @@ func InitializeServer() (Server, error) {
 	}
 	userService := mongo.NewMongoUserService(logger, env, appConfig, userRepository)
 	client := utils.NewSendgridClient(env)
-	emailService, err := sendgrid.NewSendgridEmailService(logger, appConfig, client, userService)
+	emailService, err := sendgrid.NewSendgridEmailService(logger, appConfig, env, client, userService)
 	if err != nil {
 		return Server{}, err
 	}


### PR DESCRIPTION
For issue #28 

Users are now able to get a new verification email. When a user with auth level `Unverified` logs in, they get redirected a page telling them that their email is unverified and provides a link to send a new verification email to their email address.

Implements:
 - Verification resend functionality
 - Page for users with auth level `Unverified` which provides a link to send a new verification email to their email address.
 - Page for when users try to verify their email with an invalid token which provides information on how to get a new token
