### PR TITLE
Add warning of soft team member count limit

### DIFF
--- a/templates/pages/profile.gohtml
+++ b/templates/pages/profile.gohtml
@@ -24,7 +24,7 @@
               </div>
             </div>
             {{if lt .Data.User.AuthLevel 4}}
-              {{template "teamPanel.gohtml" .Data}}
+              {{template "teamPanel.gohtml" .}}
             {{end}}
           </div>
           {{if ge .Data.User.AuthLevel 4}}

--- a/templates/partials/teamPanel.gohtml
+++ b/templates/partials/teamPanel.gohtml
@@ -1,19 +1,20 @@
-{{ if .Team}}
+{{ if .Data.Team}}
   <div class="col-md-6 col-lg-5">
     <div class="card">
       <div class="card-header card-header-tabs card-header-primary">
         <h4 class="card-title">Team Information</h4>
       </div>
       <div class="card-body">
-          <h2 class="text-center text">Team name: {{.Team.Name}}</h2>
-          <h3 class="text-center text">Team ID: {{.Team.ID.Hex}}</h3>
+          <h2 class="text-center text">Team name: {{.Data.Team.Name}}</h2>
+          <h3 class="text-center text">Team ID: {{.Data.Team.ID.Hex}}</h3>
         <div class="form-group">
-          {{ if  ne (len .Teammates)  0 }}
+          {{ if  ne (len .Data.Teammates)  0 }}
           <div id="teamMemberList">
             <h3>Teammates:</h3>
-            {{range .Teammates}}
-            <p>{{.Name}} {{if eq .ID.String $.Team.Creator.String}}<i class="fas fa-crown" style="color: Gold"></i>{{end}}</p>
+            {{range .Data.Teammates}}
+            <p>{{.Name}} {{if eq .ID.String $.Data.Team.Creator.String}}<i class="fas fa-crown" style="color: Gold"></i>{{end}}</p>
             {{end}}
+            <small class="text-muted">Teams of more than {{.Cfg.SoftMaxTeamMembers}} people will not be able to compete for prizes</small>
           {{end}}
           </div>
           <form action="/team/leave" method="post">


### PR DESCRIPTION
For issue #45 

Adds a small warning on the team panel on the profile page that teams of more than 4 people will not be able to compete for prizes.