### PR TITLE
Add mongo data folder to dockerignore in prod

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 .dockerignore
 *Dockerfile*
 *docker-compose*
+data


### PR DESCRIPTION
Resolves issue #56 

Adds the mongo database `data` folder to docker ignore. Ensures docker doesn't attempt to bundle the folder during the build process