### PR TITLE
Add dynamic warning for team member count limit

### DIFF
--- a/templates/partials/teamPanel.gohtml
+++ b/templates/partials/teamPanel.gohtml
@@ -14,7 +14,7 @@
             {{range .Data.Teammates}}
             <p>{{.Name}} {{if eq .ID.String $.Data.Team.Creator.String}}<i class="fas fa-crown" style="color: Gold"></i>{{end}}</p>
             {{end}}
-            <small class="text-muted">Teams of more than {{.Cfg.SoftMaxTeamMembers}} people will not be able to compete for prizes</small>
+            <small class="{{ if  ge (len .Data.Teammates) .Cfg.SoftMaxTeamMembers }}text-danger font-weight-bold text-uppercase{{else}}text-muted{{end}}"> Teams of more than {{.Cfg.SoftMaxTeamMembers}} people will not be able to compete for prizes</small>
           {{end}}
           </div>
           <form action="/team/leave" method="post">


### PR DESCRIPTION
for issue #45

Edited the warning message so that if the member count limit is exceeded, the warning would become red, capitalized and bold.