### PR TITLE
Email should be case-insensitive during login

### DIFF
--- a/services/mongo/userService.go
+++ b/services/mongo/userService.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/unicsmcr/hs_auth/config"
@@ -35,9 +36,11 @@ func NewMongoUserService(logger *zap.Logger, env *environment.Env, cfg *config.A
 }
 
 func (s *mongoUserService) CreateUser(ctx context.Context, name, email, password string) (*entities.User, error) {
+	formattedEmail := strings.ToLower(email)
+
 	// check if email is not taken
 	res := s.userRepository.FindOne(ctx, bson.M{
-		string(entities.UserEmail): email,
+		string(entities.UserEmail): formattedEmail,
 	})
 
 	err := res.Err()
@@ -56,7 +59,7 @@ func (s *mongoUserService) CreateUser(ctx context.Context, name, email, password
 	user := &entities.User{
 		ID:        primitive.NewObjectID(),
 		Name:      name,
-		Email:     email,
+		Email:     formattedEmail,
 		Password:  pwdHash,
 		AuthLevel: s.cfg.BaseAuthLevel,
 	}
@@ -145,7 +148,7 @@ func (s *mongoUserService) GetUserWithID(ctx context.Context, userID string) (*e
 
 func (s *mongoUserService) GetUserWithEmail(ctx context.Context, email string) (*entities.User, error) {
 	res := s.userRepository.FindOne(ctx, bson.M{
-		string(entities.UserEmail): email,
+		string(entities.UserEmail): strings.ToLower(email),
 	})
 
 	user, err := decodeUserResult(res)

--- a/services/mongo/userService_test.go
+++ b/services/mongo/userService_test.go
@@ -192,15 +192,20 @@ func Test_CreateUser__should_create_correct_user(t *testing.T) {
 	uService, uRepo, cleanup := setupUserTest(t)
 	defer cleanup()
 
-	user, err := uService.CreateUser(context.Background(), testUser.Name, testUser.Email, testUser.Password)
+	testUser2 := testUser
+	testUser2.ID = primitive.NewObjectID()
+	testUser2.Email = "TesT2@emaiL.CoM"
+	testUser2FormattedEmail := "test2@email.com"
+
+	user, err := uService.CreateUser(context.Background(), testUser2.Name, testUser2.Email, testUser2.Password)
 	assert.NoError(t, err)
 
-	assert.Equal(t, testUser.Name, user.Name)
+	assert.Equal(t, testUser2.Name, user.Name)
 
 	res := uRepo.FindOne(context.Background(), bson.M{
 		string(entities.UserID):        user.ID,
-		string(entities.UserEmail):     testUser.Email,
-		string(entities.UserName):      testUser.Name,
+		string(entities.UserEmail):     testUser2FormattedEmail,
+		string(entities.UserName):      testUser2.Name,
 		string(entities.UserAuthLevel): testBaseAuthLevel,
 	})
 

--- a/services/mongo/userService_test.go
+++ b/services/mongo/userService_test.go
@@ -4,6 +4,7 @@ package mongo
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -320,6 +321,23 @@ func Test_GetUserWithEmail__should_return_expected_user(t *testing.T) {
 	assert.NoError(t, err)
 
 	user, err := uService.GetUserWithEmail(context.Background(), testUser.Email)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testUser, *user)
+}
+
+func Test_GetUserWithEmail__should_be_case_insensitive(t *testing.T) {
+	uService, uRepo, cleanup := setupUserTest(t)
+	defer cleanup()
+
+	testUser2 := testUser
+	testUser2.ID = primitive.NewObjectID()
+	testUser2.Email = "test2@email.com"
+
+	_, err := uRepo.InsertMany(context.Background(), []interface{}{testUser, testUser2})
+	assert.NoError(t, err)
+
+	user, err := uService.GetUserWithEmail(context.Background(), strings.ToUpper(testUser.Email))
 
 	assert.NoError(t, err)
 	assert.Equal(t, testUser, *user)


### PR DESCRIPTION
Resolves #59 

Email is now converted to lowercase during login or when registering a new account

Add test for checking email check is case insensitive