### PR TITLE
Fix dev env deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ It will set up 3 things:
 
 Run the following command in a terminal:
 ```
-make up
+make up-dev
 ```
 
 This will set up infrastructure illustrated in the following picture:


### PR DESCRIPTION
Noticed a small mistake in the README.

The correct command to start the app in development mode is `make up-dev` not `make up`