### PR TITLE
feat: Service token generation

### DIFF
--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -23,7 +23,7 @@ type APIV2Router interface {
 	Register(ctx *gin.Context)
 	GetUsers(ctx *gin.Context)
 	GetAuthorizedResources(ctx *gin.Context)
-	ServiceToken(ctx *gin.Context)
+	CreateServiceToken(ctx *gin.Context)
 }
 
 type apiV2Router struct {
@@ -56,7 +56,7 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 
 	tokensGroup := routerGroup.Group("/tokens")
 	tokensGroup.GET("/resources/authorized/:id", r.authorizer.WithAuthMiddleware(r, r.GetAuthorizedResources))
-	tokensGroup.POST("/service", r.authorizer.WithAuthMiddleware(r, r.ServiceToken))
+	tokensGroup.POST("/service", r.authorizer.WithAuthMiddleware(r, r.CreateServiceToken))
 }
 
 func (r *apiV2Router) GetResourcePath() string {

--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -23,6 +23,7 @@ type APIV2Router interface {
 	Register(ctx *gin.Context)
 	GetUsers(ctx *gin.Context)
 	GetAuthorizedResources(ctx *gin.Context)
+	ServiceToken(ctx *gin.Context)
 }
 
 type apiV2Router struct {
@@ -55,6 +56,7 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 
 	tokensGroup := routerGroup.Group("/tokens")
 	tokensGroup.GET("/resources/authorized/:id", r.authorizer.WithAuthMiddleware(r, r.GetAuthorizedResources))
+	tokensGroup.POST("/service", r.authorizer.WithAuthMiddleware(r, r.ServiceToken))
 }
 
 func (r *apiV2Router) GetResourcePath() string {

--- a/routers/api/v2/router_test.go
+++ b/routers/api/v2/router_test.go
@@ -21,7 +21,7 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 	}
 	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetUsers)
 	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetAuthorizedResources)
-	mockAuthMiddlewareCall(router, mockAuthorizer, router.ServiceToken)
+	mockAuthMiddlewareCall(router, mockAuthorizer, router.CreateServiceToken)
 	w := httptest.NewRecorder()
 	_, testServer := gin.CreateTestContext(w)
 	router.RegisterRoutes(&testServer.RouterGroup)

--- a/routers/api/v2/router_test.go
+++ b/routers/api/v2/router_test.go
@@ -21,6 +21,7 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 	}
 	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetUsers)
 	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetAuthorizedResources)
+	mockAuthMiddlewareCall(router, mockAuthorizer, router.ServiceToken)
 	w := httptest.NewRecorder()
 	_, testServer := gin.CreateTestContext(w)
 	router.RegisterRoutes(&testServer.RouterGroup)

--- a/routers/api/v2/tokens.go
+++ b/routers/api/v2/tokens.go
@@ -1,0 +1,60 @@
+package v2
+
+import (
+	"github.com/gin-gonic/gin"
+	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
+	"github.com/unicsmcr/hs_auth/routers/api/models"
+	"go.uber.org/zap"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func (r *apiV2Router) ServiceToken(ctx *gin.Context) {
+	owner := ctx.PostForm("owner")
+	allowedURIs := ctx.PostForm("allowedURIs")
+	expiresAt := ctx.PostForm("expiresAt")
+
+	if len(owner) == 0 {
+		r.logger.Debug("service name was not provided in request")
+		models.SendAPIError(ctx, http.StatusBadRequest, "service name for the token must be provided")
+		return
+	}
+
+	if len(allowedURIs) == 0 {
+		r.logger.Debug("no allowedURIs were provided in request")
+		models.SendAPIError(ctx, http.StatusBadRequest, "at least one allowedURI must be provided")
+		return
+	}
+
+	uriList := strings.Split(allowedURIs, ",")
+	var parsedURIs []v2.UniformResourceIdentifier
+	for _, uriString := range uriList {
+		uri, err := v2.NewURIFromString(uriString)
+		if err != nil {
+			r.logger.Error("provided URI could not be parsed", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "invalid URI string in allowedURIs")
+			return
+		}
+		parsedURIs = append(parsedURIs, uri)
+	}
+
+	var expiresAtParsed int64
+	expiresAtParsed, err := strconv.ParseInt(expiresAt, 10, 64)
+	if err != nil {
+		r.logger.Error("expiresAt time could not be parsed", zap.Error(err))
+		models.SendAPIError(ctx, http.StatusBadRequest, "expiresAt must be an integer")
+		return
+	}
+
+	token, err := r.authorizer.CreateServiceToken(owner, parsedURIs, expiresAtParsed)
+	if err != nil {
+		r.logger.Error("could not create JWT", zap.Error(err))
+		models.SendAPIError(ctx, http.StatusInternalServerError, "there was a problem with creating service token")
+		return
+	}
+
+	ctx.JSON(http.StatusOK, serviceTokenRes{
+		Token: token,
+	})
+}

--- a/routers/api/v2/tokens.go
+++ b/routers/api/v2/tokens.go
@@ -24,7 +24,7 @@ func (r *apiV2Router) CreateServiceToken(ctx *gin.Context) {
 	}
 	err := ctx.Bind(&req)
 	if err != nil {
-		r.logger.Debug(err.Error())
+		r.logger.Debug("could not parse service token request", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusBadRequest, "failed to parse request")
 		return
 	}
@@ -46,7 +46,7 @@ func (r *apiV2Router) CreateServiceToken(ctx *gin.Context) {
 	for i, uriString := range uriList {
 		err = parsedURIs[i].UnmarshalJSON([]byte(uriString))
 		if err != nil {
-			r.logger.Error("provided URI could not be parsed", zap.Error(err))
+			r.logger.Debug("provided URI could not be parsed", zap.Error(err))
 			models.SendAPIError(ctx, http.StatusBadRequest, "invalid URI string in allowedURIs")
 			return
 		}

--- a/routers/api/v2/tokens.go
+++ b/routers/api/v2/tokens.go
@@ -27,6 +27,11 @@ func (r *apiV2Router) ServiceToken(ctx *gin.Context) {
 		return
 	}
 
+	// expiresAt is optional in the form, the default value is -1, i.e. never expires
+	if len(expiresAt) == 0 {
+		expiresAt = "-1"
+	}
+
 	uriList := strings.Split(allowedURIs, ",")
 	var parsedURIs []v2.UniformResourceIdentifier
 	for _, uriString := range uriList {
@@ -39,15 +44,14 @@ func (r *apiV2Router) ServiceToken(ctx *gin.Context) {
 		parsedURIs = append(parsedURIs, uri)
 	}
 
-	var expiresAtParsed int64
-	expiresAtParsed, err := strconv.ParseInt(expiresAt, 10, 64)
+	parsedExpiresAt, err := strconv.ParseInt(expiresAt, 10, 64)
 	if err != nil {
 		r.logger.Error("expiresAt time could not be parsed", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusBadRequest, "expiresAt must be an integer")
 		return
 	}
 
-	token, err := r.authorizer.CreateServiceToken(owner, parsedURIs, expiresAtParsed)
+	token, err := r.authorizer.CreateServiceToken(owner, parsedURIs, parsedExpiresAt)
 	if err != nil {
 		r.logger.Error("could not create JWT", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "there was a problem with creating service token")

--- a/routers/api/v2/tokens.go
+++ b/routers/api/v2/tokens.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"encoding/json"
 	"github.com/gin-gonic/gin"
 	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
@@ -44,7 +45,7 @@ func (r *apiV2Router) CreateServiceToken(ctx *gin.Context) {
 	uriList := strings.Split(req.AllowedURIs, ",")
 	parsedURIs := make([]v2.UniformResourceIdentifier, len(uriList))
 	for i, uriString := range uriList {
-		err = parsedURIs[i].UnmarshalJSON([]byte(uriString))
+		err := json.Unmarshal([]byte(uriString), &parsedURIs[i])
 		if err != nil {
 			r.logger.Debug("provided URI could not be parsed", zap.Error(err))
 			models.SendAPIError(ctx, http.StatusBadRequest, "invalid URI string in allowedURIs")

--- a/routers/api/v2/tokens.go
+++ b/routers/api/v2/tokens.go
@@ -6,55 +6,56 @@ import (
 	"github.com/unicsmcr/hs_auth/routers/api/models"
 	"go.uber.org/zap"
 	"net/http"
-	"strconv"
 	"strings"
 )
 
-func (r *apiV2Router) ServiceToken(ctx *gin.Context) {
-	owner := ctx.PostForm("owner")
-	allowedURIs := ctx.PostForm("allowedURIs")
-	expiresAt := ctx.PostForm("expiresAt")
-
-	if len(owner) == 0 {
-		r.logger.Debug("service name was not provided in request")
-		models.SendAPIError(ctx, http.StatusBadRequest, "service name for the token must be provided")
+// POST: /api/v2/tokens/service
+// x-www-form-urlencoded
+// Request:	 owner string
+//			 allowedURIs string
+//			 expiresAt int64
+// Response: token string
+// Headers:  Authorization <- token
+func (r *apiV2Router) CreateServiceToken(ctx *gin.Context) {
+	var req struct {
+		Owner       string `form:"owner"`
+		AllowedURIs string `form:"allowedURIs"`
+		ExpiresAt   int64  `form:"expiresAt"`
+	}
+	err := ctx.Bind(&req)
+	if err != nil {
+		r.logger.Debug(err.Error())
+		models.SendAPIError(ctx, http.StatusBadRequest, "failed to parse request")
 		return
 	}
 
-	if len(allowedURIs) == 0 {
+	if len(req.Owner) == 0 {
+		r.logger.Debug("token owner was not provided in request")
+		models.SendAPIError(ctx, http.StatusBadRequest, "token owner must be provided")
+		return
+	}
+
+	if len(req.AllowedURIs) == 0 {
 		r.logger.Debug("no allowedURIs were provided in request")
 		models.SendAPIError(ctx, http.StatusBadRequest, "at least one allowedURI must be provided")
 		return
 	}
 
-	// expiresAt is optional in the form, the default value is -1, i.e. never expires
-	if len(expiresAt) == 0 {
-		expiresAt = "-1"
-	}
-
-	uriList := strings.Split(allowedURIs, ",")
-	var parsedURIs []v2.UniformResourceIdentifier
-	for _, uriString := range uriList {
-		uri, err := v2.NewURIFromString(uriString)
+	uriList := strings.Split(req.AllowedURIs, ",")
+	parsedURIs := make([]v2.UniformResourceIdentifier, len(uriList))
+	for i, uriString := range uriList {
+		err = parsedURIs[i].UnmarshalJSON([]byte(uriString))
 		if err != nil {
 			r.logger.Error("provided URI could not be parsed", zap.Error(err))
 			models.SendAPIError(ctx, http.StatusBadRequest, "invalid URI string in allowedURIs")
 			return
 		}
-		parsedURIs = append(parsedURIs, uri)
 	}
 
-	parsedExpiresAt, err := strconv.ParseInt(expiresAt, 10, 64)
-	if err != nil {
-		r.logger.Error("expiresAt time could not be parsed", zap.Error(err))
-		models.SendAPIError(ctx, http.StatusBadRequest, "expiresAt must be an integer")
-		return
-	}
-
-	token, err := r.authorizer.CreateServiceToken(owner, parsedURIs, parsedExpiresAt)
+	token, err := r.authorizer.CreateServiceToken(req.Owner, parsedURIs, req.ExpiresAt)
 	if err != nil {
 		r.logger.Error("could not create JWT", zap.Error(err))
-		models.SendAPIError(ctx, http.StatusInternalServerError, "there was a problem with creating service token")
+		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
 		return
 	}
 

--- a/routers/api/v2/tokens_test.go
+++ b/routers/api/v2/tokens_test.go
@@ -1,0 +1,152 @@
+package v2
+
+import (
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/unicsmcr/hs_auth/config"
+	"github.com/unicsmcr/hs_auth/entities"
+	mock_v2 "github.com/unicsmcr/hs_auth/mocks/authorization/v2"
+	mock_services "github.com/unicsmcr/hs_auth/mocks/services"
+	mock_utils "github.com/unicsmcr/hs_auth/mocks/utils"
+	"github.com/unicsmcr/hs_auth/testutils"
+	"go.uber.org/zap"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type tokensTestSetup struct {
+	ctrl             *gomock.Controller
+	router           APIV2Router
+	mockAuthorizer   *mock_v2.MockAuthorizer
+	mockTimeProvider *mock_utils.MockTimeProvider
+	testUser         *entities.User
+	testCtx          *gin.Context
+	w                *httptest.ResponseRecorder
+}
+
+func setupTokensTest(t *testing.T) *tokensTestSetup {
+	ctrl := gomock.NewController(t)
+	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
+	mockUService := mock_services.NewMockUserService(ctrl)
+	mockTimeProvider := mock_utils.NewMockTimeProvider(ctrl)
+
+	router := NewAPIV2Router(zap.NewNop(), &config.AppConfig{
+		AuthTokenLifetime: testAuthTokenLifetime,
+	}, mockAuthorizer, mockUService, mockTimeProvider)
+
+	w := httptest.NewRecorder()
+	testCtx, _ := gin.CreateTestContext(w)
+
+	return &tokensTestSetup{
+		ctrl:             ctrl,
+		router:           router,
+		mockAuthorizer:   mockAuthorizer,
+		mockTimeProvider: mockTimeProvider,
+		testCtx:          testCtx,
+		w:                w,
+	}
+}
+
+func TestApiV2Router_CreateServiceToken(t *testing.T) {
+	tests := []struct {
+		name            string
+		prep            func(prep *tokensTestSetup)
+		testOwner       string
+		testAllowedURIs string
+		testExpiresAt   string
+		wantResCode     int
+		wantRes         *serviceTokenRes
+	}{
+		{
+			name:            "should return 200 when request is valid with one allowed URI",
+			testOwner:       "hs_application",
+			testAllowedURIs: "\"hs:hs_application\"",
+			testExpiresAt:   "100",
+			prep: func(setup *tokensTestSetup) {
+				setup.mockAuthorizer.EXPECT().CreateServiceToken("hs_application", gomock.Any(), int64(100)).
+					Return("test_token", nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &serviceTokenRes{
+				Token: "test_token",
+			},
+		},
+		{
+			name:            "should return 200 when request is valid with multiple allowed URIs",
+			testOwner:       "hs_application",
+			testAllowedURIs: "\"hs:hs_application\",\"hs:hs_hub\"",
+			prep: func(setup *tokensTestSetup) {
+				setup.mockAuthorizer.EXPECT().CreateServiceToken("hs_application", gomock.Any(), int64(0)).
+					Return("test_token", nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &serviceTokenRes{
+				Token: "test_token",
+			},
+		},
+		{
+			name:            "should return 400 when owner is not provided",
+			testAllowedURIs: "\"hs:hs_application\"",
+			wantResCode:     http.StatusBadRequest,
+		},
+		{
+			name:        "should return 400 when allowedURIs is not provided",
+			testOwner:   "hs_application",
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:          "should return 400 when expiresAt isn't int64",
+			testOwner:     "hs_auth",
+			testExpiresAt: "0test",
+			wantResCode:   http.StatusBadRequest,
+		},
+		{
+			name:            "should return 400 when allowedURIs are malformed",
+			testOwner:       "hs_auth",
+			testAllowedURIs: "\"??##test##??\"",
+			wantResCode:     http.StatusBadRequest,
+		},
+		{
+			name:            "should return 500 when CreateServiceToken returns unknown error",
+			testOwner:       "hs_auth",
+			testAllowedURIs: "\"hs:hs_application\"",
+			prep: func(setup *tokensTestSetup) {
+				setup.mockAuthorizer.EXPECT().CreateServiceToken("hs_auth", gomock.Any(), int64(0)).
+					Return("", errors.New("random error")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupTokensTest(t)
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx,
+				http.MethodPost,
+				map[string]string{
+					"owner":       tt.testOwner,
+					"allowedURIs": tt.testAllowedURIs,
+					"expiresAt":   tt.testExpiresAt,
+				},
+			)
+
+			setup.router.CreateServiceToken(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+
+			if tt.wantRes != nil {
+				var actualRes serviceTokenRes
+				err := testutils.UnmarshallResponse(setup.w.Body, &actualRes)
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.wantRes, actualRes)
+			}
+		})
+	}
+}

--- a/routers/api/v2/types.go
+++ b/routers/api/v2/types.go
@@ -9,6 +9,10 @@ type loginRes struct {
 	Token string `json:"token"`
 }
 
+type serviceTokenRes struct {
+	Token string `json:"token"`
+}
+
 type getUsersRes struct {
 	Users []entities.User `json:"users"`
 }


### PR DESCRIPTION
Resolves #73 

This PR implements a route for auth v2 that generates an service token with the provided values of `expiresAt`, `allowedURIs` and `owner`.

We have discussed offline that the `allowedURIs` might not be needed in the JWT since those values will be stored in the DB which allows us to invalidate the service tokens more easily.