### PR TITLE
feat: Implement GetUser and GetUsers for API v2

### DIFF
--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -26,6 +26,8 @@ type authorizerTestSetup struct {
 	ctrl               *gomock.Controller
 }
 
+var testUserId = primitive.NewObjectID()
+
 func setupAuthorizerTests(t *testing.T, jwtSecret string) authorizerTestSetup {
 	restore := testutils.SetEnvVars(map[string]string{
 		environment.JWTSecret: jwtSecret,
@@ -239,19 +241,13 @@ func TestAuthorizer_WithAuthMiddleware_should_call_HandleUnauthorized(t *testing
 		{
 			name: "when token is empty",
 			prep: func(setup *authorizerTestSetup) {
-				setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return("", nil).Times(1)
-			},
-		},
-		{
-			name: "when GetAuthToken returns err",
-			prep: func(setup *authorizerTestSetup) {
-				setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return("123123", errors.New("test err")).Times(1)
+				setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return("").Times(1)
 			},
 		},
 		{
 			name: "when GetAuthorizedResources returns err",
 			prep: func(setup *authorizerTestSetup) {
-				setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return("invalid_token", nil).Times(1)
+				setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return("invalid_token").Times(1)
 				setup.mockRouterResource.EXPECT().GetResourcePath().Return("resource").Times(1)
 			},
 		},
@@ -281,7 +277,7 @@ func TestAuthorizer_WithAuthMiddleware_should_call_handler_when_request_is_autho
 	mockHandler := func(*gin.Context) { mockHandlerCalled = true }
 
 	token := createToken(t, "test_token", nil, int64(10000), service, "")
-	setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return(token, nil).Times(1)
+	setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return(token).Times(1)
 	setup.mockRouterResource.EXPECT().GetResourcePath().Return("resource").Times(1)
 
 	wrappedHandler := setup.authorizer.WithAuthMiddleware(setup.mockRouterResource, mockHandler)
@@ -289,6 +285,54 @@ func TestAuthorizer_WithAuthMiddleware_should_call_handler_when_request_is_autho
 	wrappedHandler(setup.testCtx)
 
 	assert.True(t, mockHandlerCalled)
+}
+
+func TestAuthorizer_GetUserIdFromToken__should_return_error(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		wantErr    error
+		wantUserId primitive.ObjectID
+	}{
+		{
+			name:    "when token is empty",
+			token:   "",
+			wantErr: ErrInvalidToken,
+		},
+		{
+			name:    "when token type is not user",
+			token:   createToken(t, "id", nil, int64(10000), service, ""),
+			wantErr: ErrInvalidTokenType,
+		},
+		{
+			name:    "when user id is malformed",
+			token:   createToken(t, "invalid id", nil, int64(10000), user, ""),
+			wantErr: ErrInvalidToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupAuthorizerTests(t, "")
+			defer setup.ctrl.Finish()
+
+			userId, err := setup.authorizer.GetUserIdFromToken(tt.token)
+
+			assert.Equal(t, tt.wantUserId, userId)
+			assert.Equal(t, tt.wantErr, errors.Cause(err))
+		})
+	}
+}
+
+func TestAuthorizer_GetUserIdFromToken__should_return_correct_user_id(t *testing.T) {
+	setup := setupAuthorizerTests(t, "")
+	defer setup.ctrl.Finish()
+	token := createToken(t, testUserId.Hex(), nil, int64(10000), user, "")
+
+	userId, err := setup.authorizer.GetUserIdFromToken(token)
+
+	assert.Equal(t, testUserId, userId)
+	assert.NoError(t, err)
 }
 
 func createToken(t *testing.T, id string, allowedResources []UniformResourceIdentifier, timeToLive int64, tokenType TokenType, jwtSecret string) string {

--- a/authorization/v2/errors.go
+++ b/authorization/v2/errors.go
@@ -7,4 +7,6 @@ var (
 	ErrInvalidToken = errors.New("invalid token")
 	// ErrInvalidURI is returned when the provided URI string is invalid or cannot be parsed
 	ErrInvalidURI = errors.New("invalid URI string")
+	// ErrInvalidTokenType is returned when the type of the token is invalid for the requested operation
+	ErrInvalidTokenType = errors.New("invalid token type for requested operation")
 )

--- a/authorization/v2/resources/resources.go
+++ b/authorization/v2/resources/resources.go
@@ -12,7 +12,7 @@ type Resource interface {
 type RouterResource interface {
 	Resource
 	// GetAuthToken extracts the authorization token from given request
-	GetAuthToken(ctx *gin.Context) (string, error)
+	GetAuthToken(ctx *gin.Context) string
 	// HandleUnauthorized handles an unauthorized request
 	HandleUnauthorized(ctx *gin.Context)
 }

--- a/entities/user.go
+++ b/entities/user.go
@@ -8,12 +8,12 @@ import (
 type UserField string
 
 const (
-	UserID            UserField = "_id"
-	UserName          UserField = "name"
-	UserEmail         UserField = "email"
-	UserPassword      UserField = "password"
-	UserAuthLevel     UserField = "auth_level"
-	UserTeam          UserField = "team"
+	UserID        UserField = "_id"
+	UserName      UserField = "name"
+	UserEmail     UserField = "email"
+	UserPassword  UserField = "password"
+	UserAuthLevel UserField = "auth_level"
+	UserTeam      UserField = "team"
 )
 
 // User is the struct to store registered users
@@ -24,5 +24,6 @@ type User struct {
 	Password      string             `json:"-" bson:"password" validate:"required,min=6,max=160"`
 	EmailVerified bool               `json:"email_verified,omitempty" bson:"email_verified,omitempty"`
 	AuthLevel     common.AuthLevel   `json:"auth_level" bson:"auth_level" validate:"min=0,max=3"`
-	Team          primitive.ObjectID `json:"team,omitempty" bson:"team,omitempty"`
+	// TODO: omit team from JSON when team is primitive.NilObjectID
+	Team primitive.ObjectID `json:"team,omitempty" bson:"team,omitempty"`
 }

--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -5,11 +5,9 @@ import (
 	"github.com/pkg/errors"
 	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
 	"github.com/unicsmcr/hs_auth/config"
-	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
 	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/utils"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
 	"net/http"
 )
@@ -22,6 +20,7 @@ type APIV2Router interface {
 	Login(ctx *gin.Context)
 	Register(ctx *gin.Context)
 	GetUsers(ctx *gin.Context)
+	GetUser(ctx *gin.Context)
 	GetAuthorizedResources(ctx *gin.Context)
 }
 
@@ -50,6 +49,7 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 
 	usersGroup := routerGroup.Group("/users")
 	usersGroup.GET("/", r.authorizer.WithAuthMiddleware(r, r.GetUsers))
+	usersGroup.GET("/:id", r.authorizer.WithAuthMiddleware(r, r.GetUser))
 	usersGroup.POST("/", r.Register)
 	usersGroup.POST("/login", r.Login)
 
@@ -61,30 +61,12 @@ func (r *apiV2Router) GetResourcePath() string {
 	return resourcePath
 }
 
-func (r *apiV2Router) GetAuthToken(ctx *gin.Context) (string, error) {
-	return ctx.GetHeader(authTokenHeader), nil
+func (r *apiV2Router) GetAuthToken(ctx *gin.Context) string {
+	return ctx.GetHeader(authTokenHeader)
 }
 
 func (r *apiV2Router) HandleUnauthorized(ctx *gin.Context) {
 	models.SendAPIError(ctx, http.StatusUnauthorized, "you are not authorized to use this operation")
-}
-
-// TODO: finish implementation (https://github.com/unicsmcr/hs_auth/issues/89)
-func (r *apiV2Router) GetUsers(ctx *gin.Context) {
-	ctx.JSON(http.StatusOK, getUsersRes{
-		Users: []entities.User{
-			{
-				ID:    primitive.NewObjectID(),
-				Name:  "Bob the Tester",
-				Email: "bob@test.com",
-			},
-			{
-				ID:    primitive.NewObjectID(),
-				Name:  "Rob the Tester",
-				Email: "rob@test.com",
-			},
-		},
-	})
 }
 
 // TODO: finish implementation (https://github.com/unicsmcr/hs_auth/issues/83)
@@ -92,12 +74,7 @@ func (r *apiV2Router) GetAuthorizedResources(ctx *gin.Context) {
 	// TODO: extract URIs from request, requires string -> URI mapper
 	var requestedUris []v2.UniformResourceIdentifier
 
-	token, err := r.GetAuthToken(ctx)
-	if err != nil {
-		r.logger.Debug("could not extract auth token", zap.Error(err))
-		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
-		return
-	}
+	token := r.GetAuthToken(ctx)
 
 	authorizedUris, err := r.authorizer.GetAuthorizedResources(token, requestedUris)
 	if err != nil {

--- a/routers/api/v2/router_test.go
+++ b/routers/api/v2/router_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	mock_v2 "github.com/unicsmcr/hs_auth/mocks/authorization/v2"
+	mock_services "github.com/unicsmcr/hs_auth/mocks/services"
+	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/testutils"
 	"go.uber.org/zap"
 	"net/http"
@@ -15,12 +17,16 @@ import (
 func TestApiV2Router_RegisterRoutes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
+	mockUService := mock_services.NewMockUserService(ctrl)
 	router := &apiV2Router{
-		logger:     zap.NewNop(),
-		authorizer: mockAuthorizer,
+		logger:      zap.NewNop(),
+		authorizer:  mockAuthorizer,
+		userService: mockUService,
 	}
 	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetUsers)
+	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetUser)
 	mockAuthMiddlewareCall(router, mockAuthorizer, router.GetAuthorizedResources)
+	mockUService.EXPECT().GetUserWithID(gomock.Any(), gomock.Any()).Return(nil, services.ErrNotFound)
 	w := httptest.NewRecorder()
 	_, testServer := gin.CreateTestContext(w)
 	router.RegisterRoutes(&testServer.RouterGroup)
@@ -35,6 +41,10 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 		},
 		{
 			route:  "/users",
+			method: http.MethodGet,
+		},
+		{
+			route:  "/users/123",
 			method: http.MethodGet,
 		},
 		{
@@ -73,8 +83,7 @@ func TestApiV2Router_GetAuthToken(t *testing.T) {
 	ctx.Request = req
 	router := &apiV2Router{}
 
-	actualToken, err := router.GetAuthToken(ctx)
-	assert.NoError(t, err)
+	actualToken := router.GetAuthToken(ctx)
 	assert.Equal(t, token, actualToken)
 }
 

--- a/routers/api/v2/types.go
+++ b/routers/api/v2/types.go
@@ -13,6 +13,10 @@ type getUsersRes struct {
 	Users []entities.User `json:"users"`
 }
 
+type getUserRes struct {
+	User entities.User `json:"user"`
+}
+
 type getAuthorizedResourcesRes struct {
 	AuthorizedUris []v2.UniformResourceIdentifier `json:"authorizedUris"`
 }

--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -3,8 +3,11 @@ package v2
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
+	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
 	"github.com/unicsmcr/hs_auth/services"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
 	"net/http"
 )
@@ -89,4 +92,127 @@ func (r *apiV2Router) Register(ctx *gin.Context) {
 	// TODO: add email verification (https://github.com/unicsmcr/hs_auth/issues/87)
 
 	ctx.Status(http.StatusOK)
+}
+
+// GET: /api/v2/users
+// Response: users []entities.User
+// Headers:  Authorization -> token
+func (r *apiV2Router) GetUsers(ctx *gin.Context) {
+	var (
+		users []entities.User
+		err   error
+	)
+	if ctx.Query("team") != "" {
+		users, err = r.getTeamMembersCtxAware(ctx, ctx.Query("team"))
+	} else {
+		users, err = r.userService.GetUsers(ctx)
+	}
+
+	if err != nil {
+		switch errors.Cause(err) {
+		case v2.ErrInvalidToken:
+			r.logger.Debug("invalid token", zap.Error(err))
+			r.HandleUnauthorized(ctx)
+		case v2.ErrInvalidTokenType:
+			r.logger.Debug("invalid token type", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "provided token is of invalid type for the requested operation")
+		case services.ErrInvalidID:
+			r.logger.Debug("invalid id", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "invalid id")
+		case services.ErrNotFound:
+			r.logger.Debug("user not found", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusNotFound, "user not found")
+		case services.ErrUserNotInTeam:
+			r.logger.Debug("user is not in a team", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "user not found")
+		default:
+			r.logger.Error("could not fetch user", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, getUsersRes{Users: users})
+}
+
+// GET: /api/v2/users/(:id|me)
+// Response: user entities.User
+// Headers:  Authorization -> token
+func (r *apiV2Router) GetUser(ctx *gin.Context) {
+	var (
+		user *entities.User
+		err  error
+	)
+	user, err = r.getUserCtxAware(ctx, ctx.Param("id"))
+	if err != nil {
+		switch errors.Cause(err) {
+		case v2.ErrInvalidToken:
+			r.logger.Debug("invalid token", zap.Error(err))
+			r.HandleUnauthorized(ctx)
+		case v2.ErrInvalidTokenType:
+			r.logger.Debug("invalid token type", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "provided token is of invalid type for the requested operation")
+		case services.ErrInvalidID:
+			r.logger.Debug("invalid user id", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "invalid user id")
+		case services.ErrNotFound:
+			r.logger.Debug("user not found", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusNotFound, "user not found")
+		default:
+			r.logger.Error("could not fetch user", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, getUserRes{
+		User: *user,
+	})
+}
+
+// getUserCtxAware fetches user with the given id. If id is "me", getUserCtxAware tries to extract the user from the ctx
+func (r *apiV2Router) getUserCtxAware(ctx *gin.Context, userId string) (*entities.User, error) {
+	if userId == "me" {
+		token := r.GetAuthToken(ctx)
+		userIdObj, err := r.authorizer.GetUserIdFromToken(token)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not extract user id from auth token")
+		}
+
+		userId = userIdObj.Hex()
+	}
+
+	user, err := r.userService.GetUserWithID(ctx, userId)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch user")
+	}
+
+	return user, nil
+}
+
+// getTeamMembersCtxAware fetches team members for team with the given id.
+// If id is "me", getTeamMembersCtxAware tries to extract the team from the ctx
+func (r *apiV2Router) getTeamMembersCtxAware(ctx *gin.Context, teamId string) ([]entities.User, error) {
+	var (
+		members []entities.User
+		err     error
+	)
+	if teamId == "me" {
+		token := r.GetAuthToken(ctx)
+		var userIdObj primitive.ObjectID
+		userIdObj, err = r.authorizer.GetUserIdFromToken(token)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not extract user id from auth token")
+		}
+
+		members, err = r.userService.GetTeamMembersForUserWithID(ctx, userIdObj.Hex())
+	} else {
+		members, err = r.userService.GetUsersWithTeam(ctx, teamId)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch team members")
+	}
+
+	return members, nil
 }

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -2,9 +2,11 @@ package v2
 
 import (
 	"errors"
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
 	"github.com/unicsmcr/hs_auth/config"
 	"github.com/unicsmcr/hs_auth/entities"
 	mock_v2 "github.com/unicsmcr/hs_auth/mocks/authorization/v2"
@@ -20,7 +22,15 @@ import (
 	"time"
 )
 
-const testAuthTokenLifetime = 10000000
+const (
+	testAuthTokenLifetime = 10000000
+	testAuthToken         = "authToken"
+)
+
+var (
+	testUserId = primitive.NewObjectID()
+	testTeamId = primitive.NewObjectID()
+)
 
 type usersTestSetup struct {
 	ctrl             *gomock.Controller
@@ -47,10 +57,10 @@ func setupUsersTest(t *testing.T) *usersTestSetup {
 	testCtx, _ := gin.CreateTestContext(w)
 
 	testUser := entities.User{
-		ID:       primitive.NewObjectID(),
+		ID:       testUserId,
 		Name:     "Bob the Tester",
 		Email:    "test@email.com",
-		Team:     primitive.NewObjectID(),
+		Team:     testTeamId,
 		Password: "password123",
 	}
 
@@ -248,6 +258,338 @@ func TestApiV2Router_Register(t *testing.T) {
 			setup.router.Register(setup.testCtx)
 
 			assert.Equal(t, tt.wantResCode, setup.w.Code)
+		})
+	}
+}
+
+func TestApiV2Router_GetUsers(t *testing.T) {
+	tests := []struct {
+		name        string
+		teamId      string
+		prep        func(*usersTestSetup)
+		wantResCode int
+		wantRes     *getUsersRes
+	}{
+		{
+			name: "should return 500 when team id not specified and users service returns err",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUsers(gomock.Any()).Return(nil, errors.New("service err")).
+					Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 401 when team id is me and authorizer returns ErrInvalidToken",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:   "should return 400 when team id is me and authorizer returns ErrInvalidTokenType",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidTokenType).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 400 when team id is me and user service returns ErrInvalidID",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetTeamMembersForUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 404 when team id is me and user service returns ErrNotFound",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetTeamMembersForUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrNotFound).Times(1)
+			},
+			wantResCode: http.StatusNotFound,
+		},
+		{
+			name:   "should return 400 when team id is me and user service returns ErrUserNotInTeam",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetTeamMembersForUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrUserNotInTeam).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 500 when team id is me and user service returns unknown error",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetTeamMembersForUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 400 when team id is specified and user service returns ErrInvalidId",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUsersWithTeam(setup.testCtx, testTeamId.Hex()).
+					Return(nil, services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 500 when team id is specified and user service returns unknown error",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUsersWithTeam(setup.testCtx, testTeamId.Hex()).
+					Return(nil, errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 200 and expected result when team id is me",
+			teamId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetTeamMembersForUserWithID(setup.testCtx, testUserId.Hex()).
+					Return([]entities.User{
+						{
+							Name: "Bob the Tester",
+						},
+						{
+							Name: "Rob the Tester",
+						},
+					}, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getUsersRes{
+				Users: []entities.User{
+					{
+						Name: "Bob the Tester",
+					},
+					{
+						Name: "Rob the Tester",
+					},
+				},
+			},
+		},
+		{
+			name:   "should return 200 and expected result when team id is specified",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUsersWithTeam(setup.testCtx, testTeamId.Hex()).
+					Return([]entities.User{
+						{
+							Name: "Bob the Tester",
+						},
+						{
+							Name: "Rob the Tester",
+						},
+					}, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getUsersRes{
+				Users: []entities.User{
+					{
+						Name: "Bob the Tester",
+					},
+					{
+						Name: "Rob the Tester",
+					},
+				},
+			},
+		},
+		{
+			name: "should return 200 and expected result when team id not specified",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUsers(gomock.Any()).Return([]entities.User{
+					{
+						Name: "Bob the Tester",
+					},
+					{
+						Name: "Rob the Tester",
+					},
+				}, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getUsersRes{
+				Users: []entities.User{
+					{
+						Name: "Bob the Tester",
+					},
+					{
+						Name: "Rob the Tester",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupUsersTest(t)
+			defer setup.ctrl.Finish()
+			var req *http.Request
+			if tt.teamId != "" {
+				req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/test?team=%s", tt.teamId), nil)
+			} else {
+				req = httptest.NewRequest(http.MethodGet, "/test", nil)
+			}
+			setup.testCtx.Request = req
+			setup.testCtx.Request.Header.Set(authTokenHeader, testAuthToken)
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.GetUsers(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+
+			if tt.wantRes != nil {
+				var actualRes getUsersRes
+				err := testutils.UnmarshallResponse(setup.w.Body, &actualRes)
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.wantRes, actualRes)
+			}
+		})
+	}
+}
+
+func TestApiV2Router_GetUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		userId      string
+		prep        func(*usersTestSetup)
+		wantResCode int
+		wantRes     *getUserRes
+	}{
+		{
+			name:   "should return 401 when user id is me and authorizer returns ErrInvalidToken",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:   "should return 400 when user id is me and authorizer returns ErrInvalidTokenType",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidTokenType).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 500 when user id is me and authorizer returns unknown err",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, errors.New("some err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 400 when user service returns ErrInvalidID",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 404 when user service returns ErrNotFound",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrNotFound).Times(1)
+			},
+			wantResCode: http.StatusNotFound,
+		},
+		{
+			name:   "should return 500 when user service returns unknown error",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, errors.New("some err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 200 and correct user when user id is specified",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(setup.testUser, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getUserRes{
+				User: entities.User{
+					ID:       testUserId,
+					Name:     "Bob the Tester",
+					Email:    "test@email.com",
+					Team:     testTeamId,
+					Password: "",
+				},
+			},
+		},
+		{
+			name:   "should return 200 and correct user when user id is me",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(setup.testUser, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getUserRes{
+				User: entities.User{
+					ID:       testUserId,
+					Name:     "Bob the Tester",
+					Email:    "test@email.com",
+					Team:     testTeamId,
+					Password: "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupUsersTest(t)
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodGet, nil)
+			setup.testCtx.Request.Header.Set(authTokenHeader, testAuthToken)
+			testutils.AddUrlParamsToCtx(setup.testCtx, map[string]string{"id": tt.userId})
+			defer setup.ctrl.Finish()
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.GetUser(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+
+			if tt.wantRes != nil {
+				var actualRes getUserRes
+				err := testutils.UnmarshallResponse(setup.w.Body, &actualRes)
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.wantRes, actualRes)
+			}
 		})
 	}
 }

--- a/services/mongo/userService.go
+++ b/services/mongo/userService.go
@@ -184,7 +184,7 @@ func (s *mongoUserService) GetUserWithJWT(ctx context.Context, jwt string) (*ent
 	return s.GetUserWithID(ctx, claims.Id)
 }
 
-func (s *mongoUserService) GetTeammatesForUserWithID(ctx context.Context, userID string) ([]entities.User, error) {
+func (s *mongoUserService) GetTeamMembersForUserWithID(ctx context.Context, userID string) ([]entities.User, error) {
 	user, err := s.GetUserWithID(ctx, userID)
 	if err != nil {
 		return nil, err
@@ -199,9 +199,18 @@ func (s *mongoUserService) GetTeammatesForUserWithID(ctx context.Context, userID
 		return nil, err
 	}
 
+	return teamMembers, nil
+}
+
+func (s *mongoUserService) GetTeammatesForUserWithID(ctx context.Context, userID string) ([]entities.User, error) {
+	teamMembers, err := s.GetTeamMembersForUserWithID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
 	// removing the given user from the list of team members to ensure only the teammates are returned
 	for i, member := range teamMembers {
-		if member.ID == user.ID {
+		if member.ID.Hex() == userID {
 			teamMembers = append(teamMembers[:i], teamMembers[i+1:]...)
 			break
 		}

--- a/services/userService.go
+++ b/services/userService.go
@@ -48,6 +48,8 @@ type UserService interface {
 	GetUserWithEmailAndPwd(ctx context.Context, email, pwd string) (*entities.User, error)
 	GetUserWithJWT(ctx context.Context, jwt string) (*entities.User, error)
 
+	GetTeamMembersForUserWithID(ctx context.Context, userID string) ([]entities.User, error)
+
 	GetTeammatesForUserWithID(ctx context.Context, userID string) ([]entities.User, error)
 	GetTeammatesForUserWithJWT(ctx context.Context, jwt string) ([]entities.User, error)
 


### PR DESCRIPTION
For issue #89 

Implements operations `GetUser` and `GetUsers` as described in the [specification](https://documenter.getpostman.com/view/2489646/T1DjjKP6?version=latest#59ac18d2-708b-430f-89f9-29e60f12c296).