### PR TITLE
chore: Make TokenClaims struct private

### DIFF
--- a/authorization/v2/authorizer.go
+++ b/authorization/v2/authorizer.go
@@ -49,7 +49,7 @@ type authorizer struct {
 
 func (a *authorizer) CreateUserToken(userId primitive.ObjectID, expirationDate int64) (string, error) {
 	timestamp := a.timeProvider.Now().Unix()
-	token := jwt.NewWithClaims(jwtSigningMethod, TokenClaims{
+	token := jwt.NewWithClaims(jwtSigningMethod, tokenClaims{
 		StandardClaims: jwt.StandardClaims{
 			Id:        userId.Hex(),
 			IssuedAt:  timestamp,
@@ -63,7 +63,7 @@ func (a *authorizer) CreateUserToken(userId primitive.ObjectID, expirationDate i
 
 func (a *authorizer) CreateServiceToken(owner string, allowedResources []UniformResourceIdentifier, expirationDate int64) (string, error) {
 	timestamp := a.timeProvider.Now().Unix()
-	token := jwt.NewWithClaims(jwtSigningMethod, TokenClaims{
+	token := jwt.NewWithClaims(jwtSigningMethod, tokenClaims{
 		StandardClaims: jwt.StandardClaims{
 			Id:        owner,
 			IssuedAt:  timestamp,
@@ -139,13 +139,13 @@ func (a *authorizer) GetUserIdFromToken(token string) (primitive.ObjectID, error
 	return userId, nil
 }
 
-func getTokenClaims(token string, jwtSecret string) (TokenClaims, error) {
-	var claims TokenClaims
+func getTokenClaims(token string, jwtSecret string) (tokenClaims, error) {
+	var claims tokenClaims
 	_, err := jwt.ParseWithClaims(token, &claims, func(*jwt.Token) (interface{}, error) {
 		return []byte(jwtSecret), nil
 	})
 	if err != nil {
-		return TokenClaims{}, errors.Wrap(err, "could not parse token claims")
+		return tokenClaims{}, errors.Wrap(err, "could not parse token claims")
 	}
 	return claims, nil
 }

--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -60,35 +60,35 @@ func TestAuthorizer_CreateServiceToken(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		checks func(claims TokenClaims)
+		checks func(claims tokenClaims)
 	}{
 		{
 			name: "should use correct Id",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testOwner, claims.Id)
 			},
 		},
 		{
 			name: "should use correct IssuedAt",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testTimestamp.Unix(), claims.IssuedAt)
 			},
 		},
 		{
 			name: "should use correct ExpiresAt",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testTimestamp.Unix()+testTTL, claims.ExpiresAt)
 			},
 		},
 		{
 			name: "should use correct TokenType",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, service, claims.TokenType)
 			},
 		},
 		{
 			name: "should use correct AllowedResources",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testAllowedResources, claims.AllowedResources)
 			},
 		},
@@ -117,29 +117,29 @@ func TestAuthorizer_CreateUserToken(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		checks func(claims TokenClaims)
+		checks func(claims tokenClaims)
 	}{
 		{
 			name: "should use correct Id",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testUserId.Hex(), claims.Id)
 			},
 		},
 		{
 			name: "should use correct IssuedAt",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testTimestamp.Unix(), claims.IssuedAt)
 			},
 		},
 		{
 			name: "should use correct ExpiresAt",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, testTimestamp.Unix()+testTTL, claims.ExpiresAt)
 			},
 		},
 		{
 			name: "should use correct TokenType",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, user, claims.TokenType)
 			},
 		},
@@ -336,7 +336,7 @@ func TestAuthorizer_GetUserIdFromToken__should_return_correct_user_id(t *testing
 }
 
 func createToken(t *testing.T, id string, allowedResources []UniformResourceIdentifier, timeToLive int64, tokenType TokenType, jwtSecret string) string {
-	token := jwt.NewWithClaims(jwtSigningMethod, TokenClaims{
+	token := jwt.NewWithClaims(jwtSigningMethod, tokenClaims{
 		StandardClaims: jwt.StandardClaims{
 			Id:        id,
 			IssuedAt:  time.Now().Unix(),
@@ -352,8 +352,8 @@ func createToken(t *testing.T, id string, allowedResources []UniformResourceIden
 	return tokenStr
 }
 
-func extractTokenClaims(t *testing.T, token string, jwtSecret string) TokenClaims {
-	var claims TokenClaims
+func extractTokenClaims(t *testing.T, token string, jwtSecret string) tokenClaims {
+	var claims tokenClaims
 	_, err := jwt.ParseWithClaims(token, &claims, func(*jwt.Token) (interface{}, error) {
 		return []byte(jwtSecret), nil
 	})

--- a/authorization/v2/types.go
+++ b/authorization/v2/types.go
@@ -7,7 +7,7 @@ type TokenType string
 const user TokenType = "user"
 const service TokenType = "service"
 
-type TokenClaims struct {
+type tokenClaims struct {
 	jwt.StandardClaims
 	TokenType        `json:"token_type"`
 	AllowedResources []UniformResourceIdentifier `json:"allowed_resources,omitempty"`


### PR DESCRIPTION
Makes the `TokenClaims` struct used by the `Authorizer` private. `TokenClaims` stores the contents of v2 auth tokens. Logic for parsing, creating and extracting information from tokens should be localized to the `authorization/v2` package and as such `TokenClaims` should be a private struct.