### PR TITLE
feat: Implement teams API v2

### DIFF
--- a/authorization/v2/authorizer.go
+++ b/authorization/v2/authorizer.go
@@ -31,7 +31,7 @@ type Authorizer interface {
 	WithAuthMiddleware(router resources.RouterResource, handler gin.HandlerFunc) gin.HandlerFunc
 	// GetUserIdFromToken extracts the user id from user tokens
 	GetUserIdFromToken(token string) (primitive.ObjectID, error)
-	// GetTokenTypeFromToke extracts the token type from the given token
+	// GetTokenTypeFromToken extracts the token type from the given token
 	GetTokenTypeFromToken(token string) (TokenType, error)
 }
 

--- a/authorization/v2/authorizer.go
+++ b/authorization/v2/authorizer.go
@@ -147,6 +147,11 @@ func (a *authorizer) GetTokenTypeFromToken(token string) (TokenType, error) {
 		return "", errors.Wrap(ErrInvalidToken, err.Error())
 	}
 
+	err = verifyTokenType(claims.TokenType)
+	if err != nil {
+		return "", errors.Wrap(ErrInvalidToken, err.Error())
+	}
+
 	return claims.TokenType, nil
 }
 

--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -83,7 +83,7 @@ func TestAuthorizer_CreateServiceToken(t *testing.T) {
 		},
 		{
 			name: "should use correct TokenType",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, Service, claims.TokenType)
 			},
 		},
@@ -140,7 +140,7 @@ func TestAuthorizer_CreateUserToken(t *testing.T) {
 		},
 		{
 			name: "should use correct TokenType",
-			checks: func(claims TokenClaims) {
+			checks: func(claims tokenClaims) {
 				assert.Equal(t, User, claims.TokenType)
 			},
 		},
@@ -259,7 +259,7 @@ func TestAuthorizer_WithAuthMiddleware_should_call_HandleUnauthorized(t *testing
 		{
 			name: "when GetAuthorizedResources returns empty array",
 			prep: func(setup *authorizerTestSetup) {
-				token := createToken(t, "test_token", nil, int64(10000), service, "")
+				token := createToken(t, "test_token", nil, int64(10000), Service, "")
 				setup.mockRouterResource.EXPECT().GetAuthToken(gomock.Any()).Return(token).Times(1)
 				setup.mockRouterResource.EXPECT().GetResourcePath().Return("resource").Times(1)
 			},

--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -345,6 +345,17 @@ func TestAuthorizer_GetTokenTypeFromToken__should_return_error_when_token_is_inv
 	assert.Equal(t, ErrInvalidToken, errors.Cause(err))
 }
 
+func TestAuthorizer_GetTokenTypeFromToken__should_return_error_when_token_type_is_invalid(t *testing.T) {
+	setup := setupAuthorizerTests(t, "")
+	defer setup.ctrl.Finish()
+	token := createToken(t, testUserId.Hex(), nil, int64(10000), "invalid token type", "")
+
+	tokenType, err := setup.authorizer.GetTokenTypeFromToken(token)
+
+	assert.Zero(t, tokenType)
+	assert.Equal(t, ErrInvalidToken, errors.Cause(err))
+}
+
 func TestAuthorizer_GetTokenTypeFromToken__should_return_expected_token_type(t *testing.T) {
 	setup := setupAuthorizerTests(t, "")
 	defer setup.ctrl.Finish()

--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -338,22 +338,22 @@ func TestAuthorizer_GetUserIdFromToken__should_return_correct_user_id(t *testing
 func TestAuthorizer_GetTokenTypeFromToken__should_return_error_when_token_is_invalid(t *testing.T) {
 	setup := setupAuthorizerTests(t, "")
 	defer setup.ctrl.Finish()
+
+	tokenType, err := setup.authorizer.GetTokenTypeFromToken("invalid token")
+
+	assert.Zero(t, tokenType)
+	assert.Equal(t, ErrInvalidToken, errors.Cause(err))
+}
+
+func TestAuthorizer_GetTokenTypeFromToken__should_return_expected_token_type(t *testing.T) {
+	setup := setupAuthorizerTests(t, "")
+	defer setup.ctrl.Finish()
 	token := createToken(t, testUserId.Hex(), nil, int64(10000), User, "")
 
 	tokenType, err := setup.authorizer.GetTokenTypeFromToken(token)
 
 	assert.Equal(t, User, tokenType)
 	assert.NoError(t, err)
-}
-
-func TestAuthorizer_GetTokenTypeFromToken__should_return_expected_token_type(t *testing.T) {
-	setup := setupAuthorizerTests(t, "")
-	defer setup.ctrl.Finish()
-
-	tokenType, err := setup.authorizer.GetTokenTypeFromToken("invalid token")
-
-	assert.Zero(t, tokenType)
-	assert.Equal(t, ErrInvalidToken, errors.Cause(err))
 }
 
 func createToken(t *testing.T, id string, allowedResources []UniformResourceIdentifier, timeToLive int64, tokenType TokenType, jwtSecret string) string {

--- a/authorization/v2/types.go
+++ b/authorization/v2/types.go
@@ -4,8 +4,8 @@ import "github.com/dgrijalva/jwt-go"
 
 type TokenType string
 
-const user TokenType = "user"
-const service TokenType = "service"
+const User TokenType = "user"
+const Service TokenType = "service"
 
 type TokenClaims struct {
 	jwt.StandardClaims

--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -23,6 +23,9 @@ type APIV2Router interface {
 	GetUser(ctx *gin.Context)
 	GetAuthorizedResources(ctx *gin.Context)
 	CreateServiceToken(ctx *gin.Context)
+	CreateTeam(ctx *gin.Context)
+	GetTeams(ctx *gin.Context)
+	GetTeam(ctx *gin.Context)
 }
 
 type apiV2Router struct {
@@ -31,17 +34,19 @@ type apiV2Router struct {
 	cfg          *config.AppConfig
 	authorizer   v2.Authorizer
 	userService  services.UserService
+	teamService  services.TeamService
 	timeProvider utils.TimeProvider
 }
 
 func NewAPIV2Router(logger *zap.Logger, cfg *config.AppConfig, authorizer v2.Authorizer,
-	userService services.UserService, timeProvider utils.TimeProvider) APIV2Router {
+	userService services.UserService, teamService services.TeamService, timeProvider utils.TimeProvider) APIV2Router {
 	return &apiV2Router{
 		logger:       logger,
 		cfg:          cfg,
 		authorizer:   authorizer,
 		userService:  userService,
 		timeProvider: timeProvider,
+		teamService:  teamService,
 	}
 }
 
@@ -57,6 +62,11 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	tokensGroup := routerGroup.Group("/tokens")
 	tokensGroup.GET("/resources/authorized/:id", r.authorizer.WithAuthMiddleware(r, r.GetAuthorizedResources))
 	tokensGroup.POST("/service", r.authorizer.WithAuthMiddleware(r, r.CreateServiceToken))
+
+	teamsGroups := routerGroup.Group("/teams")
+	teamsGroups.GET("/", r.authorizer.WithAuthMiddleware(r, r.GetTeams))
+	teamsGroups.GET("/:id", r.authorizer.WithAuthMiddleware(r, r.GetTeam))
+	teamsGroups.POST("/", r.authorizer.WithAuthMiddleware(r, r.CreateTeam))
 }
 
 func (r *apiV2Router) GetResourcePath() string {

--- a/routers/api/v2/teams.go
+++ b/routers/api/v2/teams.go
@@ -1,0 +1,159 @@
+package v2
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
+	"github.com/unicsmcr/hs_auth/entities"
+	"github.com/unicsmcr/hs_auth/routers/api/models"
+	"github.com/unicsmcr/hs_auth/services"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+// POST: /api/v2/teams
+// x-www-form-urlencoded
+// Request:  name string
+// Response: team entities.Team
+// Headers:  Authorization -> token
+func (r *apiV2Router) CreateTeam(ctx *gin.Context) {
+	teamName := ctx.PostForm("name")
+	if len(teamName) == 0 {
+		r.logger.Debug("team name not provided")
+		models.SendAPIError(ctx, http.StatusBadRequest, "team name must be provided")
+		return
+	}
+
+	var (
+		err  error
+		team *entities.Team
+	)
+	tokenType, err := r.authorizer.GetTokenTypeFromToken(r.GetAuthToken(ctx))
+	if err != nil {
+		switch errors.Cause(err) {
+		case v2.ErrInvalidToken:
+			r.logger.Debug("invalid token", zap.Error(err))
+			r.HandleUnauthorized(ctx)
+		default:
+			r.logger.Error("could not extract token type", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		}
+		return
+	}
+
+	if tokenType == v2.User {
+		var userId primitive.ObjectID
+		userId, err = r.authorizer.GetUserIdFromToken(r.GetAuthToken(ctx))
+		if err != nil {
+			switch errors.Cause(err) {
+			case v2.ErrInvalidToken:
+				r.logger.Debug("invalid token", zap.Error(err))
+				r.HandleUnauthorized(ctx)
+			case v2.ErrInvalidTokenType:
+				r.logger.Debug("invalid token type", zap.Error(err))
+				models.SendAPIError(ctx, http.StatusBadRequest, "provided token is of invalid type for the requested operation")
+			default:
+				r.logger.Error("could not extract token type", zap.Error(err))
+				models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+			}
+			return
+		}
+
+		team, err = r.teamService.CreateTeamForUserWithID(ctx, teamName, userId.Hex())
+	} else if tokenType == v2.Service {
+		team, err = r.teamService.CreateTeam(ctx, teamName, primitive.NilObjectID.Hex())
+	}
+
+	if err != nil {
+		switch errors.Cause(err) {
+		case services.ErrInvalidID:
+			r.logger.Debug("invalid user id", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "invalid user id")
+		case services.ErrNameTaken:
+			r.logger.Debug("team name taken", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "given team name is already taken")
+		case services.ErrUserInTeam:
+			r.logger.Debug("user is already in a team", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "user is already in a team")
+		default:
+			r.logger.Error("could not create team", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, createTeamRes{
+		Team: *team,
+	})
+}
+
+// GET: /api/v2/teams
+// Response: teams []entities.Team
+// Headers:  Authorization -> token
+func (r *apiV2Router) GetTeams(ctx *gin.Context) {
+	teams, err := r.teamService.GetTeams(ctx)
+	if err != nil {
+		r.logger.Error("could not fetch teams", zap.Error(err))
+		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+	}
+
+	ctx.JSON(http.StatusOK, getTeamsRes{
+		Teams: teams,
+	})
+}
+
+// GET: /api/v2/teams/(:id|me)
+// Response: team entities.Team
+// Headers:  Authorization -> token
+func (r *apiV2Router) GetTeam(ctx *gin.Context) {
+	team, err := r.getTeamCtxAware(ctx, ctx.Param("id"))
+	if err != nil {
+		switch errors.Cause(err) {
+		case v2.ErrInvalidToken:
+			r.logger.Debug("invalid token", zap.Error(err))
+			r.HandleUnauthorized(ctx)
+		case v2.ErrInvalidTokenType:
+			r.logger.Debug("invalid token type", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "provided token is of invalid type for the requested operation")
+		case services.ErrInvalidID:
+			r.logger.Debug("invalid id", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusBadRequest, "invalid id")
+		case services.ErrNotFound:
+			r.logger.Debug("team not found", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusNotFound, "team not found")
+		default:
+			r.logger.Error("could not fetch team", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, getTeamRes{
+		Team: *team,
+	})
+}
+
+func (r *apiV2Router) getTeamCtxAware(ctx *gin.Context, teamId string) (*entities.Team, error) {
+	var (
+		team *entities.Team
+		err  error
+	)
+	if teamId == "me" {
+		var userId primitive.ObjectID
+		userId, err = r.authorizer.GetUserIdFromToken(r.GetAuthToken(ctx))
+		if err != nil {
+			return nil, err
+		}
+
+		team, err = r.teamService.GetTeamForUserWithID(ctx, userId.Hex())
+	} else {
+		team, err = r.teamService.GetTeamWithID(ctx, teamId)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch team")
+	}
+
+	return team, nil
+}

--- a/routers/api/v2/teams_test.go
+++ b/routers/api/v2/teams_test.go
@@ -1,0 +1,458 @@
+package v2
+
+import (
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
+	"github.com/unicsmcr/hs_auth/config"
+	"github.com/unicsmcr/hs_auth/entities"
+	mock_v2 "github.com/unicsmcr/hs_auth/mocks/authorization/v2"
+	mock_services "github.com/unicsmcr/hs_auth/mocks/services"
+	mock_utils "github.com/unicsmcr/hs_auth/mocks/utils"
+	"github.com/unicsmcr/hs_auth/services"
+	"github.com/unicsmcr/hs_auth/testutils"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type teamsTestSetup struct {
+	ctrl           *gomock.Controller
+	router         APIV2Router
+	mockAuthorizer *mock_v2.MockAuthorizer
+	mockTService   *mock_services.MockTeamService
+	testTeam       *entities.Team
+	testCtx        *gin.Context
+	w              *httptest.ResponseRecorder
+}
+
+func setupTeamsTest(t *testing.T) *teamsTestSetup {
+	ctrl := gomock.NewController(t)
+	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
+	mockTimeProvider := mock_utils.NewMockTimeProvider(ctrl)
+	mockTService := mock_services.NewMockTeamService(ctrl)
+
+	router := NewAPIV2Router(zap.NewNop(), &config.AppConfig{
+		AuthTokenLifetime: testAuthTokenLifetime,
+	}, mockAuthorizer, nil, mockTService, mockTimeProvider)
+
+	w := httptest.NewRecorder()
+	testCtx, _ := gin.CreateTestContext(w)
+
+	testTeam := entities.Team{
+		ID:      testTeamId,
+		Name:    "Bobs the Testers",
+		Creator: testUserId,
+	}
+
+	return &teamsTestSetup{
+		ctrl:           ctrl,
+		router:         router,
+		mockAuthorizer: mockAuthorizer,
+		testCtx:        testCtx,
+		w:              w,
+		testTeam:       &testTeam,
+		mockTService:   mockTService,
+	}
+}
+
+func TestApiV2Router_GetTeams(t *testing.T) {
+	tests := []struct {
+		name        string
+		prep        func(setup *teamsTestSetup)
+		wantResCode int
+		wantRes     *getTeamsRes
+	}{
+		{
+			name: "should return 500 when team service returns error",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockTService.EXPECT().GetTeams(setup.testCtx).Return(nil, errors.New("service err")).
+					Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name: "should return 200 and expected teams",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockTService.EXPECT().GetTeams(setup.testCtx).Return([]entities.Team{
+					{
+						Name: "Bobs the Testers",
+					},
+					{
+						Name: "Robs the Testers",
+					},
+				}, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getTeamsRes{
+				Teams: []entities.Team{
+					{
+						Name: "Bobs the Testers",
+					},
+					{
+						Name: "Robs the Testers",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupTeamsTest(t)
+			defer setup.ctrl.Finish()
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.GetTeams(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+
+			if tt.wantRes != nil {
+				var actualRes getTeamsRes
+				err := testutils.UnmarshallResponse(setup.w.Body, &actualRes)
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.wantRes, actualRes)
+			}
+		})
+	}
+}
+
+func TestApiV2Router_GetTeam(t *testing.T) {
+	tests := []struct {
+		name        string
+		teamId      string
+		prep        func(setup *teamsTestSetup)
+		wantResCode int
+		wantRes     *getTeamRes
+	}{
+		{
+			name:   "should return 401 when user id is me and authorizer returns ErrInvalidToken",
+			teamId: "me",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:   "should return 400 when user id is me and authorizer returns ErrInvalidTokenType",
+			teamId: "me",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidTokenType).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 500 when user id is me and authorizer returns unknown err",
+			teamId: "me",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, errors.New("some err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 400 when team service returns ErrInvalidID",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *teamsTestSetup) {
+				setup.mockTService.EXPECT().GetTeamWithID(setup.testCtx, testTeamId.Hex()).
+					Return(nil, services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 404 when team service returns ErrNotFound",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *teamsTestSetup) {
+				setup.mockTService.EXPECT().GetTeamWithID(setup.testCtx, testTeamId.Hex()).
+					Return(nil, services.ErrNotFound).Times(1)
+			},
+			wantResCode: http.StatusNotFound,
+		},
+		{
+			name:   "should return 500 when team service returns unknown error",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *teamsTestSetup) {
+				setup.mockTService.EXPECT().GetTeamWithID(setup.testCtx, testTeamId.Hex()).
+					Return(nil, errors.New("some err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 200 and correct team when team id is specified",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *teamsTestSetup) {
+				setup.mockTService.EXPECT().GetTeamWithID(setup.testCtx, testTeamId.Hex()).
+					Return(setup.testTeam, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getTeamRes{
+				Team: entities.Team{
+					ID:      testTeamId,
+					Name:    "Bobs the Testers",
+					Creator: testUserId,
+				},
+			},
+		},
+		{
+			name:   "should return 200 and correct user when user id is me",
+			teamId: "me",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).Return(testUserId, nil).Times(1)
+				setup.mockTService.EXPECT().GetTeamForUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(setup.testTeam, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getTeamRes{
+				Team: entities.Team{
+					ID:      testTeamId,
+					Name:    "Bobs the Testers",
+					Creator: testUserId,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupTeamsTest(t)
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodGet, nil)
+			setup.testCtx.Request.Header.Set(authTokenHeader, testAuthToken)
+			testutils.AddUrlParamsToCtx(setup.testCtx, map[string]string{"id": tt.teamId})
+			defer setup.ctrl.Finish()
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.GetTeam(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+
+			if tt.wantRes != nil {
+				var actualRes getTeamRes
+				err := testutils.UnmarshallResponse(setup.w.Body, &actualRes)
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.wantRes, actualRes)
+			}
+		})
+	}
+}
+
+func TestApiV2Router_CreateTeam(t *testing.T) {
+	tests := []struct {
+		name        string
+		teamName    string
+		prep        func(setup *teamsTestSetup)
+		wantResCode int
+		wantRes     *createTeamRes
+	}{
+		{
+			name:        "should return 400 when team name is not provided",
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 401 when authorizer.GetTokenTypeFromToken returns ErrInvalidToken",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.TokenType(""), v2.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "should return 401 when authorizer.GetTokenTypeFromToken returns unknown error",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.TokenType(""), errors.New("authorizer err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "should return 400 when token type is service and CreateTeam returns ErrInvalidID",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.Service, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeam(setup.testCtx, "Bobs_the_Testers", primitive.NilObjectID.Hex()).
+					Return(nil, services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 400 when token type is service and CreateTeam returns ErrNameTaken",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.Service, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeam(setup.testCtx, "Bobs_the_Testers", primitive.NilObjectID.Hex()).
+					Return(nil, services.ErrNameTaken).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 400 when token type is service and CreateTeam returns unknown error",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.Service, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeam(setup.testCtx, "Bobs_the_Testers", primitive.NilObjectID.Hex()).
+					Return(nil, errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "should return 401 when token type is user and GetUserIdFromToken returns ErrInvalidToken",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "should return 400 when token type is user and GetUserIdFromToken returns ErrInvalidTokenType",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, v2.ErrInvalidTokenType).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 500 when token type is user and GetUserIdFromToken returns unknown error",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, errors.New("authorizer err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "should return 400 when token type is user and CreateTeamForUserWithID returns ErrInvalidID",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeamForUserWithID(setup.testCtx, "Bobs_the_Testers", testUserId.Hex()).
+					Return(nil, services.ErrInvalidID)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 400 when token type is user and CreateTeamForUserWithID returns ErrNameTaken",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeamForUserWithID(setup.testCtx, "Bobs_the_Testers", testUserId.Hex()).
+					Return(nil, services.ErrNameTaken)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 400 when token type is user and CreateTeamForUserWithID returns ErrUserInTeam",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeamForUserWithID(setup.testCtx, "Bobs_the_Testers", testUserId.Hex()).
+					Return(nil, services.ErrUserInTeam)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:     "should return 500 when token type is user and CreateTeamForUserWithID returns unknown error",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeamForUserWithID(setup.testCtx, "Bobs_the_Testers", testUserId.Hex()).
+					Return(nil, errors.New("service err"))
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "should return 200 and expected team when token type is service",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.Service, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeam(setup.testCtx, "Bobs_the_Testers", primitive.NilObjectID.Hex()).
+					Return(setup.testTeam, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &createTeamRes{
+				Team: entities.Team{
+					ID:      testTeamId,
+					Name:    "Bobs the Testers",
+					Creator: testUserId,
+				},
+			},
+		},
+		{
+			name:     "should return 200 and expected team when token type is user",
+			teamName: "Bobs_the_Testers",
+			prep: func(setup *teamsTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetTokenTypeFromToken(testAuthToken).
+					Return(v2.User, nil).Times(1)
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockTService.EXPECT().CreateTeamForUserWithID(setup.testCtx, "Bobs_the_Testers", testUserId.Hex()).
+					Return(setup.testTeam, nil)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &createTeamRes{
+				Team: entities.Team{
+					ID:      testTeamId,
+					Name:    "Bobs the Testers",
+					Creator: testUserId,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupTeamsTest(t)
+			defer setup.ctrl.Finish()
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodPost, map[string]string{"name": tt.teamName})
+			setup.testCtx.Request.Header.Set(authTokenHeader, testAuthToken)
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.CreateTeam(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+
+			if tt.wantRes != nil {
+				var actualRes createTeamRes
+				err := testutils.UnmarshallResponse(setup.w.Body, &actualRes)
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.wantRes, actualRes)
+			}
+		})
+	}
+}

--- a/routers/api/v2/tokens_test.go
+++ b/routers/api/v2/tokens_test.go
@@ -35,7 +35,7 @@ func setupTokensTest(t *testing.T) *tokensTestSetup {
 
 	router := NewAPIV2Router(zap.NewNop(), &config.AppConfig{
 		AuthTokenLifetime: testAuthTokenLifetime,
-	}, mockAuthorizer, mockUService, mockTimeProvider)
+	}, mockAuthorizer, mockUService, nil, mockTimeProvider)
 
 	w := httptest.NewRecorder()
 	testCtx, _ := gin.CreateTestContext(w)

--- a/routers/api/v2/types.go
+++ b/routers/api/v2/types.go
@@ -24,3 +24,15 @@ type getUserRes struct {
 type getAuthorizedResourcesRes struct {
 	AuthorizedUris []v2.UniformResourceIdentifier `json:"authorizedUris"`
 }
+
+type getTeamsRes struct {
+	Teams []entities.Team `json:"teams"`
+}
+
+type getTeamRes struct {
+	Team entities.Team `json:"team"`
+}
+
+type createTeamRes struct {
+	Team entities.Team `json:"team"`
+}

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -51,7 +51,7 @@ func setupUsersTest(t *testing.T) *usersTestSetup {
 
 	router := NewAPIV2Router(zap.NewNop(), &config.AppConfig{
 		AuthTokenLifetime: testAuthTokenLifetime,
-	}, mockAuthorizer, mockUService, mockTimeProvider)
+	}, mockAuthorizer, mockUService, nil, mockTimeProvider)
 
 	w := httptest.NewRecorder()
 	testCtx, _ := gin.CreateTestContext(w)

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -53,7 +53,7 @@ func InitializeServer() (Server, error) {
 	apiv1Router := v1.NewAPIV1Router(logger, appConfig, env, userService, emailService, teamService)
 	timeProvider := utils.NewTimeProvider()
 	authorizer := v2.NewAuthorizer(timeProvider, env, logger)
-	apiv2Router := v2_2.NewAPIV2Router(logger, appConfig, authorizer, userService, timeProvider)
+	apiv2Router := v2_2.NewAPIV2Router(logger, appConfig, authorizer, userService, teamService, timeProvider)
 	router := frontend.NewRouter(logger, appConfig, env, userService, teamService, emailService)
 	mainRouter := routers.NewMainRouter(logger, apiv1Router, apiv2Router, router)
 	server := NewServer(mainRouter, env)


### PR DESCRIPTION
For issue #84 

Implements the operations `GetTeams` `GetTeam` and `CreateTeam` as described in the [specification](https://documenter.getpostman.com/view/2489646/T1DjjKP6?version=latest#70577f61-4df6-4aa3-9b54-4be7e685ba6c).