### PR TITLE
feat: on-release publish docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Publish Docker Image
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and push hs_auth image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          path: ./docker/hs_auth
+          repository: unicsmcr/hs_auth
+          tag-with-ref: true


### PR DESCRIPTION
Resolves #98 

Whenever a release is published, a new docker image is built and published to [Docker Hub](https://hub.docker.com/repository/docker/unicsmcr/hs_auth)