### PR TITLE
fix: Team deleted when creator leaves

### DIFF
--- a/services/mongo/teamService.go
+++ b/services/mongo/teamService.go
@@ -266,11 +266,7 @@ func (s *mongoTeamService) RemoveUserWithIDFromTheirTeam(ctx context.Context, us
 			entities.TeamCreator: teamMembers[0].ID,
 		},
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (s *mongoTeamService) RemoveUserWithJWTFromTheirTeam(ctx context.Context, jwt string) error {

--- a/services/mongo/teamService_test.go
+++ b/services/mongo/teamService_test.go
@@ -31,12 +31,12 @@ var (
 )
 
 type teamTestSetup struct {
-	ctrl       *gomock.Controller
-	tService   *mongoTeamService
-	tRepo      *repositories.TeamRepository
-	mocService *mock_services.MockUserService
-	cleanup    func()
-	testCtx    *gin.Context
+	ctrl         *gomock.Controller
+	tService     *mongoTeamService
+	tRepo        *repositories.TeamRepository
+	mockUService *mock_services.MockUserService
+	cleanup      func()
+	testCtx      *gin.Context
 }
 
 func setupTeamTest(t *testing.T) *teamTestSetup {


### PR DESCRIPTION
For issue #61 

Changes the `TeamService` behaviour when removing a team's creator from their team to not automatically delete the team. With this change the team will only be deleted if after removing the team's creator, the team will be empty. Otherwise, it assigns a new creator to the team from the existing members.