### PR TITLE
fix: 200 returned for non-existant teams

### DIFF
--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -110,8 +110,12 @@ func (r *apiV2Router) GetUsers(ctx *gin.Context) {
 		err   error
 	)
 	if ctx.Query("team") != "" {
-		// TODO: https://github.com/unicsmcr/hs_auth/issues/68
 		users, err = r.getTeamMembersCtxAware(ctx, ctx.Query("team"))
+		if err == nil && len(users) == 0 {
+			r.logger.Debug("team not found", zap.String("team id", ctx.Query("team")))
+			models.SendAPIError(ctx, http.StatusNotFound, "team not found")
+			return
+		}
 	} else {
 		users, err = r.userService.GetUsers(ctx)
 	}

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -362,6 +362,15 @@ func TestApiV2Router_GetUsers(t *testing.T) {
 			wantResCode: http.StatusInternalServerError,
 		},
 		{
+			name:   "should return 404 when team id is specified and user service returns an empty slice",
+			teamId: testTeamId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUsersWithTeam(setup.testCtx, testTeamId.Hex()).
+					Return(nil, nil).Times(1)
+			},
+			wantResCode: http.StatusNotFound,
+		},
+		{
 			name:   "should return 200 and expected result when team id is me",
 			teamId: "me",
 			prep: func(setup *usersTestSetup) {


### PR DESCRIPTION
Closes #68 

Updates the behaviour of `GetUsers` to return a `404` when the team specified by the `team` filter is not found.