### PR TITLE
feat: Implement URI metadata validation

### DIFF
--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -216,23 +216,21 @@ func TestAuthorizer_GetAuthorizedResources_should_remove_uris_with_invalid_metad
 	jwtSecret := "test_secret"
 	setup := setupAuthorizerTests(t, jwtSecret)
 	defer setup.ctrl.Finish()
-	token := createToken(t, "testuser", []UniformResourceIdentifier{
-		{
-			path: "test",
-		},
-	}, int64(100), User, jwtSecret)
+	validUri, err := common.NewURIFromString("test")
+	assert.NoError(t, err)
+	token := createToken(t, "testuser", []common.UniformResourceIdentifier{validUri}, int64(100), User, jwtSecret)
 
 	var testTime int64 = 1000
 	setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(testTime, 0)).Times(1)
-	invalidMetadataUri, err := NewURIFromString(fmt.Sprintf("hs:hs_auth#%s=%d", before, testTime+1))
+	invalidMetadataUri, err := common.NewURIFromString(fmt.Sprintf("hs:hs_auth#%s=%d", before, testTime+1))
 	assert.NoError(t, err)
 
-	uris := []UniformResourceIdentifier{{path: "test"}, invalidMetadataUri}
+	uris := []common.UniformResourceIdentifier{validUri, invalidMetadataUri}
 
 	returnedUris, err := setup.authorizer.GetAuthorizedResources(token, uris)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []UniformResourceIdentifier{{path: "test"}}, returnedUris)
+	assert.Equal(t, []common.UniformResourceIdentifier{validUri}, returnedUris)
 }
 
 func TestAuthorizer_GetAuthorizedResources_should_ignore_uris_in_token_with_invalid_metadata(t *testing.T) {
@@ -242,13 +240,13 @@ func TestAuthorizer_GetAuthorizedResources_should_ignore_uris_in_token_with_inva
 
 	var testTime int64 = 1000
 	setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(testTime, 0)).Times(1)
-	invalidMetadataUri, err := NewURIFromString(fmt.Sprintf("hs:hs_auth#%s=%d", before, testTime+1))
+	invalidMetadataUri, err := common.NewURIFromString(fmt.Sprintf("hs:hs_auth#%s=%d", before, testTime+1))
 	assert.NoError(t, err)
 
-	token := createToken(t, "testuser", []UniformResourceIdentifier{invalidMetadataUri}, int64(100), User, jwtSecret)
+	token := createToken(t, "testuser", []common.UniformResourceIdentifier{invalidMetadataUri}, int64(100), User, jwtSecret)
 
-	testUri, err := NewURIFromString("hs:hs_auth")
-	uris := []UniformResourceIdentifier{testUri}
+	testUri, err := common.NewURIFromString("hs:hs_auth")
+	uris := []common.UniformResourceIdentifier{testUri}
 
 	returnedUris, err := setup.authorizer.GetAuthorizedResources(token, uris)
 	assert.NoError(t, err)

--- a/authorization/v2/common/uniformResourceIdentifier.go
+++ b/authorization/v2/common/uniformResourceIdentifier.go
@@ -163,7 +163,6 @@ func getHandlerName(handler gin.HandlerFunc) string {
 }
 
 func getRequestArguments(ctx *gin.Context) map[string]string {
-	// TODO: tidy this up once string -> URI -> string mapping is done
 	args := make(map[string]string)
 
 	// path
@@ -192,7 +191,7 @@ func unmarshallURIList(source string) (map[string]string, error) {
 	for index, keyValuePair := range keyValuePairs {
 		split := strings.Split(keyValuePair, "=")
 		if len(split) != 2 {
-			return nil, errors.New("malformed key value pair at index " + string(index))
+			return nil, errors.New(fmt.Sprintf("malformed key value pair at index %d", index))
 		}
 		uriListMapping[split[0]] = split[1]
 	}
@@ -247,7 +246,6 @@ func (uri UniformResourceIdentifier) isSubsetOf(target UniformResourceIdentifier
 		}
 	}
 
-	// TODO: Add URI metadata validation. See https://github.com/unicsmcr/hs_auth/pull/91#discussion_r471787861
 	return true
 }
 
@@ -259,4 +257,8 @@ func (uri UniformResourceIdentifier) IsSubsetOfAtLeastOne(targets []UniformResou
 		}
 	}
 	return false
+}
+
+func (uri UniformResourceIdentifier) GetMetadata() map[string]string {
+	return uri.metadata
 }

--- a/authorization/v2/common/uniformResourceIdentifier_test.go
+++ b/authorization/v2/common/uniformResourceIdentifier_test.go
@@ -431,19 +431,10 @@ func Test_IsSubsetOfAtLeastOne__should_return_false_when_path_doesnt_match(t *te
 	assert.Equal(t, valid, false)
 }
 
-// TODO: Uncomment once metadata validation is added
-//func Test_isSubsetOfAtLeastOne__should_return_false_when_metadata_doesnt_match(t *testing.T) {
-//	testSource := UniformResourceIdentifier{
-//		path:     "hs:hs_auth1",
-//		metadata: map[string]string{"after": "82387236"},
-//	}
-//	testTargets := []UniformResourceIdentifier{
-//		{
-//			path:     "hs:hs_auth1",
-//			metadata: map[string]string{"after": "82380236"},
-//		},
-//	}
-//
-//	valid := testSource.isSubsetOfAtLeastOne(testTargets)
-//	assert.Equal(t, valid, false)
-//}
+func TestUniformResourceIdentifier_GetMetadata(t *testing.T) {
+	testUri := UniformResourceIdentifier{
+		metadata: map[string]string{"testKey": "testValue"},
+	}
+
+	assert.Equal(t, map[string]string{"testKey": "testValue"}, testUri.GetMetadata())
+}

--- a/authorization/v2/metadata.go
+++ b/authorization/v2/metadata.go
@@ -1,0 +1,32 @@
+package v2
+
+import (
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+type metadataIdentifier string
+
+const (
+	// before metadata field can be used to ensure a URI is only valid
+	// until the Unix time specified in the before field
+	before metadataIdentifier = "before"
+)
+
+func (a *authorizer) validateMetadata(identifier metadataIdentifier, metadata string) (bool, error) {
+	switch identifier {
+	case before:
+		return a.beforeHandler(metadata)
+	default:
+		return false, errors.New("unknown metadata identifier")
+	}
+}
+
+func (a *authorizer) beforeHandler(timestampStr string) (bool, error) {
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return false, errors.Wrap(err, "could not parse provided timestamp")
+	}
+
+	return a.timeProvider.Now().Unix() > timestamp, nil
+}

--- a/authorization/v2/metadata_test.go
+++ b/authorization/v2/metadata_test.go
@@ -1,0 +1,114 @@
+package v2
+
+import (
+	"fmt"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	mock_utils "github.com/unicsmcr/hs_auth/mocks/utils"
+	"go.uber.org/zap"
+	"testing"
+	"time"
+)
+
+type metadataTestsSetup struct {
+	ctrl             *gomock.Controller
+	authorizer       *authorizer
+	mockTimeProvider *mock_utils.MockTimeProvider
+}
+
+func setupMetadataTests(t *testing.T) metadataTestsSetup {
+	ctrl := gomock.NewController(t)
+	mockTimeProvider := mock_utils.NewMockTimeProvider(ctrl)
+
+	return metadataTestsSetup{
+		ctrl: ctrl,
+		authorizer: &authorizer{
+			timeProvider: mockTimeProvider,
+			logger:       zap.NewNop(),
+		},
+		mockTimeProvider: mockTimeProvider,
+	}
+}
+
+func TestAuthorizer_validateMetadata__should_return_err_when_identifier_is_unknown(t *testing.T) {
+	setup := setupMetadataTests(t)
+
+	_, err := setup.authorizer.validateMetadata("unknown identifier", "")
+
+	assert.Error(t, err)
+}
+
+func TestAuthorizer_validateMetadata__should_return_true(t *testing.T) {
+	tests := []struct {
+		identifier    metadataIdentifier
+		prep          func(*metadataTestsSetup)
+		givenMetadata string
+	}{
+		{
+			identifier: before,
+			prep: func(setup *metadataTestsSetup) {
+				setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(1000, 0)).Times(1)
+			},
+			givenMetadata: "999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.identifier), func(t *testing.T) {
+			setup := setupMetadataTests(t)
+			defer setup.ctrl.Finish()
+
+			tt.prep(&setup)
+
+			result, err := setup.authorizer.validateMetadata(tt.identifier, tt.givenMetadata)
+
+			assert.NoError(t, err)
+			assert.True(t, result)
+		})
+	}
+}
+
+func TestAuthorizer_beforeHandler(t *testing.T) {
+	const testTime int64 = 1000
+
+	tests := []struct {
+		name       string
+		timestamp  string
+		prep       func(*metadataTestsSetup)
+		wantResult bool
+		wantErr    bool
+	}{
+		{
+			name:      "should return error when given timestamp is invalid",
+			timestamp: "not valid date",
+			wantErr:   true,
+		},
+		{
+			name:       "should return true when timestamp is in the past",
+			timestamp:  fmt.Sprintf("%d", testTime-1),
+			wantResult: true,
+		},
+		{
+			name:       "should return true when timestamp is in the future",
+			timestamp:  fmt.Sprintf("%d", testTime+1),
+			wantResult: false,
+		},
+		{
+			name:       "should return false when timestamp is the current time",
+			timestamp:  fmt.Sprint(testTime),
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupMetadataTests(t)
+			setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(testTime, 0))
+
+			result, err := setup.authorizer.beforeHandler(tt.timestamp)
+
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}


### PR DESCRIPTION
For issue #92 

Updates the `Authorizer.GetAuthorizedResources` function to validate the metadata in the URIs. Also implements and example metadata validator.