### PR TITLE
feat: Implement basic email service V2 client

### DIFF
--- a/services/emailServiceV2.go
+++ b/services/emailServiceV2.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+	"context"
+	"github.com/unicsmcr/hs_auth/entities"
+)
+
+// EmailServiceV2 is used to send out emails
+type EmailServiceV2 interface {
+	SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error
+
+	SendEmailVerificationEmail(user entities.User, emailVerificationResourcePath string) error
+	SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string, emailVerificationResourcePath string) error
+
+	SendPasswordResetEmail(user entities.User, passwordResetResourcePath string) error
+	SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResourcePath string) error
+}

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -1,22 +1,19 @@
-package sendgrid
+package v2
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"github.com/pkg/errors"
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	authV2 "github.com/unicsmcr/hs_auth/authorization/v2"
 	"github.com/unicsmcr/hs_auth/config"
 	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/environment"
 	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/utils"
-	"github.com/unicsmcr/hs_auth/utils/auth"
 	"go.uber.org/zap"
 	"html/template"
 	"net/http"
-	"time"
 )
 
 var (
@@ -30,18 +27,14 @@ type sendgridEmailService struct {
 	cfg         *config.AppConfig
 	env         *environment.Env
 	userService services.UserService
+	authorizer  authV2.Authorizer
 
 	passwordResetEmailTemplate *template.Template
 	emailVerifyEmailTemplate   *template.Template
 }
 
-type emailTemplateDataModel struct {
-	EventName  string
-	Link       string
-	SenderName string
-}
-
-func NewSendgridEmailService(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env, client *sendgrid.Client, userService services.UserService) (services.EmailService, error) {
+func NewSendgridEmailServiceV2(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env,
+	client *sendgrid.Client, userService services.UserService, authorizer authV2.Authorizer) (services.EmailServiceV2, error) {
 	passwordResetEmailTemplate, err := utils.LoadTemplate("password reset", passwordResetEmailTemplatePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load password reset template")
@@ -60,6 +53,7 @@ func NewSendgridEmailService(logger *zap.Logger, cfg *config.AppConfig, env *env
 		userService:                userService,
 		passwordResetEmailTemplate: passwordResetEmailTemplate,
 		emailVerifyEmailTemplate:   emailVerifyEmailTemplate,
+		authorizer:                 authorizer,
 	}, nil
 }
 
@@ -94,72 +88,15 @@ func (s *sendgridEmailService) SendEmail(subject, htmlBody, plainTextBody, sende
 		zap.String("sender", senderEmail))
 	return nil
 }
-func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User) error {
-	emailToken, err := auth.NewJWT(user, time.Now().Unix(), s.cfg.AuthTokenLifetime, auth.Email, []byte(s.env.Get(environment.JWTSecret)))
-	if err != nil {
-		return err
-	}
-
-	verificationURL := fmt.Sprintf("http://%s/verifyemail?token=%s", s.cfg.AppURL, emailToken)
-
-	var contentBuff bytes.Buffer
-	err = s.emailVerifyEmailTemplate.Execute(&contentBuff, emailTemplateDataModel{
-		EventName:  s.cfg.Name,
-		Link:       verificationURL,
-		SenderName: s.cfg.Email.NoreplyEmailName,
-	})
-	if err != nil {
-		return errors.Wrap(err, "could not construct email")
-	}
-
-	return s.SendEmail(
-		s.cfg.Email.EmailVerficationEmailSubj,
-		contentBuff.String(),
-		contentBuff.String(),
-		s.cfg.Email.NoreplyEmailName,
-		s.cfg.Email.NoreplyEmailAddr,
-		user.Name,
-		user.Email)
+func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User, emailVerificationResourcePath string) error {
+	panic("not implemented")
 }
-func (s *sendgridEmailService) SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string) error {
-	user, err := s.userService.GetUserWithEmail(ctx, email)
-	if err != nil {
-		return err
-	}
-
-	return s.SendEmailVerificationEmail(*user)
+func (s *sendgridEmailService) SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string, emailVerificationResourcePath string) error {
+	panic("not implemented")
 }
-func (s *sendgridEmailService) SendPasswordResetEmail(user entities.User) error {
-	emailToken, err := auth.NewJWT(user, time.Now().Unix(), s.cfg.AuthTokenLifetime, auth.Email, []byte(s.env.Get(environment.JWTSecret)))
-	if err != nil {
-		return err
-	}
-
-	resetURL := fmt.Sprintf("http://%s/resetpwd?email=%s&token=%s", s.cfg.AppURL, user.Email, emailToken)
-
-	var contentBuff bytes.Buffer
-	err = s.passwordResetEmailTemplate.Execute(&contentBuff, emailTemplateDataModel{
-		Link:       resetURL,
-		SenderName: s.cfg.Email.NoreplyEmailName,
-	})
-	if err != nil {
-		return errors.Wrap(err, "could not construct email")
-	}
-
-	return s.SendEmail(
-		s.cfg.Email.PasswordResetEmailSubj,
-		contentBuff.String(),
-		contentBuff.String(),
-		s.cfg.Email.NoreplyEmailName,
-		s.cfg.Email.NoreplyEmailAddr,
-		user.Name,
-		user.Email)
+func (s *sendgridEmailService) SendPasswordResetEmail(user entities.User, passwordResetResourcePath string) error {
+	panic("not implemented")
 }
-func (s *sendgridEmailService) SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string) error {
-	user, err := s.userService.GetUserWithEmail(ctx, email)
-	if err != nil {
-		return err
-	}
-
-	return s.SendPasswordResetEmail(*user)
+func (s *sendgridEmailService) SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResourcePath string) error {
+	panic("not implemented")
 }

--- a/services/sendgrid/v2/emailService_test.go
+++ b/services/sendgrid/v2/emailService_test.go
@@ -1,0 +1,97 @@
+package v2
+
+import (
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	_sendgridAPIKey    = "testkey"
+	_testEmailTemplate = "../testEmailTemplate.txt"
+)
+
+type response struct {
+	message string
+	status  int
+}
+
+func getTestClient(t *testing.T, expectedRequestBody string, wantResponse response) (*sendgrid.Client, *httptest.Server) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(expectedRequestBody) != 0 {
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedRequestBody, string(body))
+		}
+		w.WriteHeader(wantResponse.status)
+		w.Write([]byte(wantResponse.message))
+	}))
+
+	req := sendgrid.GetRequest(_sendgridAPIKey, "/", server.URL)
+	req.Method = http.MethodPost
+	client := sendgrid.Client{
+		Request: req,
+	}
+
+	return &client, server
+}
+
+func Test_NewSendgridEmailService__should_return_error_when_template_path_is_incorrect(t *testing.T) {
+	// password reset
+	passwordResetEmailTemplatePath = "invalid path"
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	service, err := NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+
+	// email verify
+	emailVerifyEmailTemplatePath = "invalid path"
+	passwordResetEmailTemplatePath = _testEmailTemplate
+
+	service, err = NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+}
+
+func Test_SendEmail__should_send_correct_message_to_sendgrid(t *testing.T) {
+	passwordResetEmailTemplatePath = "../testEmailTemplate.txt"
+	emailVerifyEmailTemplatePath = "../testEmailTemplate.txt"
+
+	client, server := getTestClient(t, `{"from":{"name":"Bob the Tester","email":"bob@test.com"},"subject":"test email","personalizations":[{"to":[{"name":"Rob the Tester","email":"rob@test.com"}]}],"content":[{"type":"text/plain","value":"test email body"},{"type":"text/html","value":"test email body"}]}`,
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailServiceV2(zap.NewNop(), nil, nil, client, nil, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmail("test email", "test email body", "test email body",
+		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
+
+	assert.NoError(t, err)
+}
+
+func Test_SendEmail__should_return_error_when_sendgrid_rejects_request(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusUnauthorized,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailServiceV2(zap.NewNop(), nil, nil, client, nil, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmail("test email", "test email body", "test email body",
+		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Resolves #107 

Implements a basic SendGrid client that is designed to make use of the V2 auth system. Functions for email verification and password reset emails will be implemented in separate PRs. 

The main difference from the V1 email service client right now is that the email verification/password reset email functions have an additional parameter for the email verfication/password reset resource path. The idea behind this is that the email service client will create a service token with permissions to use that specific resource and include it in the email, the user will then click a link in the email which will include the token. The user themselves will not have permissions to use the password reset or email verification operations, these permissions will be provided via the mentioned token in the email.

For example: say we have a user with ID: `1234` and we want to send them an email verification email. We would first generate a service token with the permissions to access `hs:hs_auth:api:v2:VerifyEmail?path_id=1234`, send an email with the token to the user, the user would verify their email by clicking the link (which would include the token) in the email. The user would not have permissions to use `hs:hs_auth:api:v2:VerifyEmail` directly, they would have to use the token in the email. Since we are working with a service token, we could also invalidate the token used for verifying the email after it has been used making the tokens single-use.