### PR TITLE
feat: Implement email verification for API v2

### DIFF
--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -120,14 +120,22 @@ func TestAuthorizer_CreateServiceToken(t *testing.T) {
 	}
 }
 
-func TestAuthorizer_InvalidateServiceToken(t *testing.T) {
-	testID := primitive.NewObjectID()
+func TestAuthorizer_InvalidateServiceToken__should_delete_correct_token(t *testing.T) {
 	jwtSecret := "test_secret"
+	token := createToken(t, "test_id", nil, 1000, Service, jwtSecret)
 	setup := setupAuthorizerTests(t, jwtSecret)
-	setup.mockTokenService.EXPECT().DeleteServiceToken(setup.testCtx, testID.Hex()).Return(nil).Times(1)
+	defer setup.ctrl.Finish()
+	setup.mockTokenService.EXPECT().DeleteServiceToken(setup.testCtx, "test_id").Return(nil).Times(1)
 
-	err := setup.authorizer.InvalidateServiceToken(setup.testCtx, testID.Hex())
+	err := setup.authorizer.InvalidateServiceToken(setup.testCtx, token)
 	assert.NoError(t, err)
+}
+
+func TestAuthorizer_InvalidateServiceToken__should_return_error_when_token_is_invalid(t *testing.T) {
+	setup := setupAuthorizerTests(t, "")
+
+	err := setup.authorizer.InvalidateServiceToken(setup.testCtx, "invalid token")
+	assert.Error(t, err)
 }
 
 func TestAuthorizer_CreateServiceToken_throws_unknown_error(t *testing.T) {

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -10,6 +10,12 @@ email:
   noreply_email_name: "UniCS"
   email_verification_email_subj: "Verify email"
   password_reset_email_subj: "Reset password"
+  token_lifetime: 108000 # 30 hours
 app_url: "auth.unicsmcr.com"
 data_policy_url: "https://drive.google.com/file/d/1wMcJbfEhIp9FjdNbyom4RVUoTH4xc0OB/view"
 soft_max_team_members: 4
+auth:
+  user_token_lifetime: 108000 # 30 hours
+  default_role: "unverified"
+  email_verification_required: true
+  default_email_verified_role: "applicant"

--- a/config/config.go
+++ b/config/config.go
@@ -17,11 +17,21 @@ var (
 
 // EmailConfig stores the configuration to be used by the email service
 type EmailConfig struct {
-	HelpEmailAddr             string `yaml:"help_email_addr"`
-	NoreplyEmailAddr          string `yaml:"noreply_email_addr"`
-	NoreplyEmailName          string `yaml:"noreply_email_name"`
-	EmailVerficationEmailSubj string `yaml:"email_verification_email_subj"`
-	PasswordResetEmailSubj    string `yaml:"password_reset_email_subj"`
+	HelpEmailAddr              string `yaml:"help_email_addr"`
+	NoreplyEmailAddr           string `yaml:"noreply_email_addr"`
+	NoreplyEmailName           string `yaml:"noreply_email_name"`
+	EmailVerificationEmailSubj string `yaml:"email_verification_email_subj"`
+	PasswordResetEmailSubj     string `yaml:"password_reset_email_subj"`
+	TokenLifetime              int64  `yaml:"token_lifetime"`
+}
+
+// AuthConfig stores the configuration to be used by the auth system V2
+type AuthConfig struct {
+	UserTokenLifetime         int64         `yaml:"user_token_lifetime""`
+	DefaultRole               role.UserRole `yaml:"default_role"`
+	EmailVerificationRequired bool          `yaml:"email_verification_required"`
+	// The role that gets assigned to the user after they verify their email
+	DefaultEmailVerifiedRole role.UserRole `yaml:"default_email_verified_role"`
 }
 
 // AppConfig is a struct to store non-private configuration for the project
@@ -36,6 +46,7 @@ type AppConfig struct {
 	UserRole           role.UserRoleConfig  `yaml:"role"`
 	DataPolicyURL      string               `yaml:"data_policy_url"`
 	SoftMaxTeamMembers uint                 `yaml:"soft_max_team_members"`
+	Auth               AuthConfig           `yaml:"auth"`
 }
 
 // NewAppConfig loads the project config from the config files based on the environment

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -6,4 +6,4 @@ use_secure_cookies: false
 base_auth_level: 1
 auth:
   default_role: "applicant"
-  email_verification_required: true
+  email_verification_required: false

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -4,3 +4,6 @@ app_url: "localhost:8000"
 domain_name: "localhost"
 use_secure_cookies: false
 base_auth_level: 1
+auth:
+  default_role: "applicant"
+  email_verification_required: true

--- a/routers/api/v1/users.go
+++ b/routers/api/v1/users.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+	"github.com/unicsmcr/hs_auth/config/role"
 	authlevels "github.com/unicsmcr/hs_auth/utils/auth/common"
 	"net/http"
 	"time"
@@ -247,7 +248,7 @@ func (r *apiV1Router) Register(ctx *gin.Context) {
 		return
 	}
 
-	user, err := r.userService.CreateUser(ctx, name, email, password)
+	user, err := r.userService.CreateUser(ctx, name, email, password, role.Applicant)
 	if err == services.ErrEmailTaken {
 		r.logger.Debug("email taken", zap.String("email", email))
 		models.SendAPIError(ctx, http.StatusBadRequest, "user with given email already exists")

--- a/routers/api/v1/users_test.go
+++ b/routers/api/v1/users_test.go
@@ -478,7 +478,7 @@ func Test_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", gomock.Any()).
 					Return(nil, services.ErrEmailTaken).Times(1)
 			},
 			wantResCode: http.StatusBadRequest,
@@ -489,7 +489,7 @@ func Test_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", gomock.Any()).
 					Return(nil, errors.New("service err")).Times(1)
 			},
 			wantResCode: http.StatusInternalServerError,
@@ -500,7 +500,7 @@ func Test_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", gomock.Any()).
 					Return(&entities.User{Name: "Bob the Tester"}, nil).Times(1)
 
 				setup.mockEService.EXPECT().SendEmailVerificationEmail(entities.User{Name: "Bob the Tester"}).
@@ -517,7 +517,7 @@ func Test_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", gomock.Any()).
 					Return(&entities.User{Name: "Bob the Tester"}, nil).Times(1)
 
 				setup.mockEService.EXPECT().SendEmailVerificationEmail(entities.User{Name: "Bob the Tester"}).
@@ -603,7 +603,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test token",
 			prep: func(setup *usersTestSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test token").
-					Return(&entities.User{AuthLevel:common.AuthLevel(-111)}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.AuthLevel(-111)}, nil).Times(1)
 			},
 			wantResCode: http.StatusUnauthorized,
 		},
@@ -612,7 +612,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test token",
 			prep: func(setup *usersTestSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test token").
-					Return(&entities.User{AuthLevel:common.Unverified + 1}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.Unverified + 1}, nil).Times(1)
 			},
 			wantResCode: http.StatusBadRequest,
 		},
@@ -621,7 +621,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test token",
 			prep: func(setup *usersTestSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test token").
-					Return(&entities.User{AuthLevel:common.Unverified}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.Unverified}, nil).Times(1)
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), primitive.NilObjectID.Hex(), services.UserUpdateParams{
 					entities.UserAuthLevel: common.Applicant,
 				}).Return(errors.New("service err")).Times(1)
@@ -633,7 +633,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test token",
 			prep: func(setup *usersTestSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test token").
-					Return(&entities.User{AuthLevel:common.Unverified}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.Unverified}, nil).Times(1)
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), primitive.NilObjectID.Hex(), services.UserUpdateParams{
 					entities.UserAuthLevel: common.Applicant,
 				}).Return(nil).Times(1)

--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -27,6 +27,7 @@ type APIV2Router interface {
 	SetRole(ctx *gin.Context)
 	SetPassword(ctx *gin.Context)
 	GetPasswordResetEmail(ctx *gin.Context)
+	ResendEmailVerification(ctx *gin.Context)
 	VerifyEmail(ctx *gin.Context)
 	GetAuthorizedResources(ctx *gin.Context)
 	CreateServiceToken(ctx *gin.Context)
@@ -79,6 +80,7 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	usersGroup.PUT("/:id/password", r.authorizer.WithAuthMiddleware(r, r.SetPassword))
 	usersGroup.GET("/:id/password/resetEmail", r.authorizer.WithAuthMiddleware(r, r.GetPasswordResetEmail))
 	usersGroup.PUT("/:id/email/verify", r.authorizer.WithAuthMiddleware(r, r.VerifyEmail))
+	usersGroup.GET("/:id/email/verify", r.authorizer.WithAuthMiddleware(r, r.ResendEmailVerification))
 
 	tokensGroup := routerGroup.Group("/tokens")
 	tokensGroup.GET("/resources/authorized/:id", r.authorizer.WithAuthMiddleware(r, r.GetAuthorizedResources))

--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -27,6 +27,7 @@ type APIV2Router interface {
 	SetRole(ctx *gin.Context)
 	SetPassword(ctx *gin.Context)
 	GetPasswordResetEmail(ctx *gin.Context)
+	VerifyEmail(ctx *gin.Context)
 	GetAuthorizedResources(ctx *gin.Context)
 	CreateServiceToken(ctx *gin.Context)
 	InvalidateServiceToken(ctx *gin.Context)
@@ -45,13 +46,13 @@ type apiV2Router struct {
 	userService  services.UserService
 	tokenService services.TokenService
 	teamService  services.TeamService
-	emailService services.EmailService
+	emailService services.EmailServiceV2
 	timeProvider utils.TimeProvider
 }
 
 func NewAPIV2Router(logger *zap.Logger, cfg *config.AppConfig, authorizer v2.Authorizer,
 	userService services.UserService, teamService services.TeamService, tokenService services.TokenService,
-	emailService services.EmailService, timeProvider utils.TimeProvider) APIV2Router {
+	emailService services.EmailServiceV2, timeProvider utils.TimeProvider) APIV2Router {
 	return &apiV2Router{
 		logger:       logger,
 		cfg:          cfg,
@@ -77,6 +78,7 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 	usersGroup.PUT("/:id/role", r.authorizer.WithAuthMiddleware(r, r.SetRole))
 	usersGroup.PUT("/:id/password", r.authorizer.WithAuthMiddleware(r, r.SetPassword))
 	usersGroup.GET("/:id/password/resetEmail", r.authorizer.WithAuthMiddleware(r, r.GetPasswordResetEmail))
+	usersGroup.PUT("/:id/email/verify", r.authorizer.WithAuthMiddleware(r, r.VerifyEmail))
 
 	tokensGroup := routerGroup.Group("/tokens")
 	tokensGroup.GET("/resources/authorized/:id", r.authorizer.WithAuthMiddleware(r, r.GetAuthorizedResources))

--- a/routers/api/v2/router_test.go
+++ b/routers/api/v2/router_test.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"fmt"
 	"github.com/unicsmcr/hs_auth/authorization/v2/common"
+	"github.com/unicsmcr/hs_auth/config"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,12 +25,13 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 	mockUService := mock_services.NewMockUserService(ctrl)
 	mockTService := mock_services.NewMockTeamService(ctrl)
 	mockTokenService := mock_services.NewMockTokenService(ctrl)
-	mockEService := mock_services.NewMockEmailService(ctrl)
+	mockEService := mock_services.NewMockEmailServiceV2(ctrl)
 	mockUService.EXPECT().GetUserWithID(gomock.Any(), gomock.Any()).Return(nil, services.ErrInvalidToken).AnyTimes()
 	mockTService.EXPECT().GetTeamWithID(gomock.Any(), gomock.Any()).Return(nil, services.ErrInvalidToken)
 	mockAuthorizer.EXPECT().GetUserIdFromToken(gomock.Any()).Return(primitive.ObjectID{}, common.ErrInvalidTokenType)
 	mockTokenService.EXPECT().CreateServiceToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, services.ErrInvalidToken)
 	mockAuthorizer.EXPECT().InvalidateServiceToken(gomock.Any(), gomock.Any()).Return(services.ErrInvalidID)
+	mockUService.EXPECT().UpdateUserWithID(gomock.Any(), gomock.Any(), gomock.Any()).Return(services.ErrInvalidID)
 
 	tests := []struct {
 		route  string
@@ -74,6 +76,9 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 		{
 			route:  "/users/123/password/resetEmail",
 			method: http.MethodGet,
+		}, {
+			route:  "/users/123/email/verify",
+			method: http.MethodPut,
 		},
 		{
 			route:  "/tokens/service",
@@ -106,6 +111,7 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 				teamService:  mockTService,
 				tokenService: mockTokenService,
 				emailService: mockEService,
+				cfg:          &config.AppConfig{},
 			}
 			w := httptest.NewRecorder()
 			_, testServer := gin.CreateTestContext(w)
@@ -123,6 +129,7 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 			mockAuthMiddlewareCall(router, mockAuthorizer, router.CreateTeam)
 			mockAuthMiddlewareCall(router, mockAuthorizer, router.SetTeam)
 			mockAuthMiddlewareCall(router, mockAuthorizer, router.RemoveFromTeam)
+			mockAuthMiddlewareCall(router, mockAuthorizer, router.VerifyEmail)
 
 			router.RegisterRoutes(&testServer.RouterGroup)
 

--- a/routers/api/v2/router_test.go
+++ b/routers/api/v2/router_test.go
@@ -76,9 +76,14 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 		{
 			route:  "/users/123/password/resetEmail",
 			method: http.MethodGet,
-		}, {
+		},
+		{
 			route:  "/users/123/email/verify",
 			method: http.MethodPut,
+		},
+		{
+			route:  "/users/123/email/verify",
+			method: http.MethodGet,
 		},
 		{
 			route:  "/tokens/service",
@@ -130,6 +135,7 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 			mockAuthMiddlewareCall(router, mockAuthorizer, router.SetTeam)
 			mockAuthMiddlewareCall(router, mockAuthorizer, router.RemoveFromTeam)
 			mockAuthMiddlewareCall(router, mockAuthorizer, router.VerifyEmail)
+			mockAuthMiddlewareCall(router, mockAuthorizer, router.ResendEmailVerification)
 
 			router.RegisterRoutes(&testServer.RouterGroup)
 

--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/unicsmcr/hs_auth/config/role"
 	"github.com/unicsmcr/hs_auth/utils/auth"
 	"net/http"
@@ -55,7 +56,7 @@ func (r *apiV2Router) Login(ctx *gin.Context) {
 		return
 	}
 
-	token, err := r.authorizer.CreateUserToken(user.ID, r.cfg.AuthTokenLifetime+r.timeProvider.Now().Unix())
+	token, err := r.authorizer.CreateUserToken(user.ID, r.cfg.Auth.UserTokenLifetime+r.timeProvider.Now().Unix())
 	if err != nil {
 		r.logger.Error("could not create JWT", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
@@ -88,7 +89,7 @@ func (r *apiV2Router) Register(ctx *gin.Context) {
 		return
 	}
 
-	_, err := r.userService.CreateUser(ctx, req.Name, req.Email, req.Password)
+	user, err := r.userService.CreateUser(ctx, req.Name, req.Email, req.Password, r.cfg.Auth.DefaultRole)
 	if err != nil {
 		switch errors.Cause(err) {
 		case services.ErrEmailTaken:
@@ -101,9 +102,20 @@ func (r *apiV2Router) Register(ctx *gin.Context) {
 		return
 	}
 
-	// TODO: add email verification (https://github.com/unicsmcr/hs_auth/issues/87)
-
 	ctx.Status(http.StatusOK)
+
+	if r.cfg.Auth.EmailVerificationRequired {
+		apiUri, err := common.NewURIFromString(fmt.Sprintf("%s:VerifyEmail?path_id=%s", r.GetResourcePath(), user.ID.Hex()))
+		if err != nil {
+			r.logger.Warn("could not create URI for API email verification resource", zap.Error(err))
+		} else {
+			// TODO: add resource for frontend email verification (https://github.com/unicsmcr/hs_auth/issues/106)
+			err = r.emailService.SendEmailVerificationEmail(ctx, *user, []common.UniformResourceIdentifier{apiUri})
+			if err != nil {
+				r.logger.Warn("could not send email verification email", zap.Error(err))
+			}
+		}
+	}
 }
 
 // GET: /api/v2/users
@@ -357,7 +369,7 @@ func (r *apiV2Router) SetPassword(ctx *gin.Context) {
 // Response:
 // Headers:  Authorization -> token
 func (r *apiV2Router) GetPasswordResetEmail(ctx *gin.Context) {
-	user, err := r.getUserCtxAware(ctx, ctx.Param("id"))
+	_, err := r.getUserCtxAware(ctx, ctx.Param("id"))
 	if err != nil {
 		switch errors.Cause(err) {
 		case common.ErrInvalidToken:
@@ -380,11 +392,11 @@ func (r *apiV2Router) GetPasswordResetEmail(ctx *gin.Context) {
 	}
 
 	// TODO: Update email service to use Auth V2 (see https://github.com/unicsmcr/hs_auth/issues/107)
-	err = r.emailService.SendPasswordResetEmail(*user)
-	if err != nil {
-		r.logger.Error("could not send password reset email", zap.Error(err))
-		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
-	}
+	//err = r.emailService.SendPasswordResetEmail(*user)
+	//if err != nil {
+	//	r.logger.Error("could not send password reset email", zap.Error(err))
+	//	models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+	//}
 
 	ctx.Status(http.StatusOK)
 }
@@ -430,6 +442,36 @@ func (r *apiV2Router) SetRole(ctx *gin.Context) {
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+// PUT: /api/v2/users/(:id|me)/email/verify
+// x-www-form-urlencoded
+// Headers:  Authorization -> token
+func (r *apiV2Router) VerifyEmail(ctx *gin.Context) {
+	err := r.userService.UpdateUserWithID(ctx, ctx.Param("id"), services.UserUpdateParams{
+		entities.UserRole: r.cfg.Auth.DefaultEmailVerifiedRole,
+	})
+	if err != nil {
+		switch err {
+		case services.ErrInvalidID:
+			r.logger.Debug("invalid user id")
+			models.SendAPIError(ctx, http.StatusBadRequest, "invalid user id provided")
+		case services.ErrNotFound:
+			r.logger.Debug("user not found")
+			models.SendAPIError(ctx, http.StatusNotFound, "user not found")
+		default:
+			r.logger.Error("could not update user with id", zap.Error(err))
+			models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
+		}
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+
+	err = r.authorizer.InvalidateServiceToken(ctx, r.GetAuthToken(ctx))
+	if err != nil {
+		r.logger.Warn("could not invalidate token after email verification", zap.Error(err))
+	}
 }
 
 // getUserCtxAware fetches user with the given id. If id is "me", getUserCtxAware tries to extract the user from the ctx

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -1257,3 +1257,88 @@ func TestApiV2Router_VerifyEmail(t *testing.T) {
 		})
 	}
 }
+
+func TestApiV2Router_ResendEmailVerification(t *testing.T) {
+	tests := []struct {
+		name        string
+		userId      string
+		prep        func(*usersTestSetup)
+		wantResCode int
+	}{
+		{
+			name:   "should return 401 when user id is me authorizer returns ErrInvalidToken",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(primitive.ObjectID{}, common.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusUnauthorized,
+		},
+		{
+			name:   "should return 400 when user id is provided and user service returns ErrInvalidID",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name:   "should return 404 when user id is provided and user service returns ErrNotFound",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, services.ErrNotFound).Times(1)
+			},
+			wantResCode: http.StatusNotFound,
+		},
+		{
+			name:   "should return 500 when user id is provided and user service returns unknown error",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(nil, errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 500 when email service returns error",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(&entities.User{ID: testUserId}, nil).Times(1)
+				setup.mockEService.EXPECT().SendEmailVerificationEmail(setup.testCtx, entities.User{ID: testUserId}, gomock.Any()).
+					Return(errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 200 when email verification is sent",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(&entities.User{ID: testUserId}, nil).Times(1)
+				setup.mockEService.EXPECT().SendEmailVerificationEmail(setup.testCtx, entities.User{ID: testUserId}, gomock.Any()).
+					Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupUsersTest(t)
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodGet, nil)
+			setup.testCtx.Request.Header.Set(authTokenHeader, testAuthToken)
+			testutils.AddUrlParamsToCtx(setup.testCtx, map[string]string{"id": tt.userId})
+			defer setup.ctrl.Finish()
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.ResendEmailVerification(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+		})
+	}
+}

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -46,7 +46,7 @@ type usersTestSetup struct {
 	router           APIV2Router
 	mockUService     *mock_services.MockUserService
 	mockTService     *mock_services.MockTeamService
-	mockEService     *mock_services.MockEmailService
+	mockEService     *mock_services.MockEmailServiceV2
 	mockAuthorizer   *mock_v2.MockAuthorizer
 	mockTimeProvider *mock_utils.MockTimeProvider
 	testUser         *entities.User
@@ -59,12 +59,17 @@ func setupUsersTest(t *testing.T) *usersTestSetup {
 	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
 	mockUService := mock_services.NewMockUserService(ctrl)
 	mockTService := mock_services.NewMockTeamService(ctrl)
-	mockEService := mock_services.NewMockEmailService(ctrl)
+	mockEService := mock_services.NewMockEmailServiceV2(ctrl)
 	mockTimeProvider := mock_utils.NewMockTimeProvider(ctrl)
 
 	router := NewAPIV2Router(zap.NewNop(), &config.AppConfig{
-		AuthTokenLifetime: testAuthTokenLifetime,
-		UserRole:          testRoleConfig,
+		UserRole: testRoleConfig,
+		Auth: config.AuthConfig{
+			UserTokenLifetime:         testAuthTokenLifetime,
+			DefaultRole:               role.Unverified,
+			DefaultEmailVerifiedRole:  role.Applicant,
+			EmailVerificationRequired: true,
+		},
 	}, mockAuthorizer, mockUService, mockTService, nil, mockEService, mockTimeProvider)
 
 	w := httptest.NewRecorder()
@@ -226,7 +231,7 @@ func TestApiV2Router_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", role.Unverified).
 					Return(nil, services.ErrEmailTaken).Times(1)
 			},
 			wantResCode: http.StatusBadRequest,
@@ -237,7 +242,7 @@ func TestApiV2Router_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", role.Unverified).
 					Return(nil, errors.New("service err")).Times(1)
 			},
 			wantResCode: http.StatusInternalServerError,
@@ -248,8 +253,23 @@ func TestApiV2Router_Register(t *testing.T) {
 			testEmail:    "test@email.com",
 			testPassword: "password123",
 			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", role.Unverified).
 					Return(&entities.User{Name: "Bob the Tester"}, nil).Times(1)
+				setup.mockEService.EXPECT().SendEmailVerificationEmail(setup.testCtx, entities.User{Name: "Bob the Tester"},
+					gomock.Any()).Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+		{
+			name:         "should return 200 when creating user succeeds but email verification email cannot be sent",
+			testName:     "Bob the Tester",
+			testEmail:    "test@email.com",
+			testPassword: "password123",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "Bob the Tester", "test@email.com", "password123", role.Unverified).
+					Return(&entities.User{Name: "Bob the Tester"}, nil).Times(1)
+				setup.mockEService.EXPECT().SendEmailVerificationEmail(setup.testCtx, entities.User{Name: "Bob the Tester"},
+					gomock.Any()).Return(errors.New("service err")).Times(1)
 			},
 			wantResCode: http.StatusOK,
 		},
@@ -258,6 +278,7 @@ func TestApiV2Router_Register(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setup := setupUsersTest(t)
+			defer setup.ctrl.Finish()
 			if tt.prep != nil {
 				tt.prep(setup)
 			}
@@ -1030,43 +1051,44 @@ func TestApiV2Router_GetPasswordResetEmail(t *testing.T) {
 			},
 			wantResCode: http.StatusInternalServerError,
 		},
-		{
-			name:   "should return 500 when user id is me and mail_service_returns_error",
-			userId: "me",
-			prep: func(setup *usersTestSetup) {
-				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
-					Return(testUserId, nil).Times(1)
-				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
-					Return(setup.testUser, nil).Times(1)
-				setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
-					Return(errors.New("random error")).Times(1)
-			},
-			wantResCode: http.StatusInternalServerError,
-		},
-		{
-			name:   "should return 200 when user id is me",
-			userId: "me",
-			prep: func(setup *usersTestSetup) {
-				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
-					Return(testUserId, nil).Times(1)
-				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
-					Return(setup.testUser, nil).Times(1)
-				setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
-					Return(nil).Times(1)
-			},
-			wantResCode: http.StatusOK,
-		},
-		{
-			name:   "should return 200 when user id is specified",
-			userId: testUserId.Hex(),
-			prep: func(setup *usersTestSetup) {
-				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
-					Return(setup.testUser, nil).Times(1)
-				setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
-					Return(nil).Times(1)
-			},
-			wantResCode: http.StatusOK,
-		},
+		// TODO: uncomment tests when password reset is integrated with email service v2
+		//{
+		//	name:   "should return 500 when user id is me and mail_service_returns_error",
+		//	userId: "me",
+		//	prep: func(setup *usersTestSetup) {
+		//		setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+		//			Return(testUserId, nil).Times(1)
+		//		setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+		//			Return(setup.testUser, nil).Times(1)
+		//		setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
+		//			Return(errors.New("random error")).Times(1)
+		//	},
+		//	wantResCode: http.StatusInternalServerError,
+		//},
+		//{
+		//	name:   "should return 200 when user id is me",
+		//	userId: "me",
+		//	prep: func(setup *usersTestSetup) {
+		//		setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+		//			Return(testUserId, nil).Times(1)
+		//		setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+		//			Return(setup.testUser, nil).Times(1)
+		//		setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
+		//			Return(nil).Times(1)
+		//	},
+		//	wantResCode: http.StatusOK,
+		//},
+		//{
+		//	name:   "should return 200 when user id is specified",
+		//	userId: testUserId.Hex(),
+		//	prep: func(setup *usersTestSetup) {
+		//		setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+		//			Return(setup.testUser, nil).Times(1)
+		//		setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
+		//			Return(nil).Times(1)
+		//	},
+		//	wantResCode: http.StatusOK,
+		//},
 	}
 
 	for _, tt := range tests {
@@ -1155,6 +1177,81 @@ func TestApiV2Router_SetRole(t *testing.T) {
 			}
 
 			setup.router.SetRole(setup.testCtx)
+
+			assert.Equal(t, tt.wantResCode, setup.w.Code)
+		})
+	}
+}
+
+func TestApiV2Router_VerifyEmail(t *testing.T) {
+	tests := []struct {
+		name        string
+		prep        func(*usersTestSetup)
+		wantResCode int
+	}{
+		{
+			name: "should return 400 when user service returns ErrInvalidID",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), services.UserUpdateParams{
+					entities.UserRole: role.Applicant,
+				}).Return(services.ErrInvalidID).Times(1)
+			},
+			wantResCode: http.StatusBadRequest,
+		},
+		{
+			name: "should return 404 when user service returns ErrNotFound",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), services.UserUpdateParams{
+					entities.UserRole: role.Applicant,
+				}).Return(services.ErrNotFound).Times(1)
+			},
+			wantResCode: http.StatusNotFound,
+		},
+		{
+			name: "should return 500 when user service returns unknown error",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), services.UserUpdateParams{
+					entities.UserRole: role.Applicant,
+				}).Return(errors.New("service err")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name: "should return 200 when user's role gets updated",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), services.UserUpdateParams{
+					entities.UserRole: role.Applicant,
+				}).Return(nil).Times(1)
+				setup.mockAuthorizer.EXPECT().InvalidateServiceToken(setup.testCtx, testAuthToken).Return(nil).
+					Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+		{
+			name: "should return 200 when user's role gets updated but invalidating the email token fails",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), services.UserUpdateParams{
+					entities.UserRole: role.Applicant,
+				}).Return(nil).Times(1)
+				setup.mockAuthorizer.EXPECT().InvalidateServiceToken(setup.testCtx, testAuthToken).
+					Return(common.ErrInvalidToken).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := setupUsersTest(t)
+			testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodPut, nil)
+			setup.testCtx.Request.Header.Set(authTokenHeader, testAuthToken)
+			testutils.AddUrlParamsToCtx(setup.testCtx, map[string]string{"id": testUserId.Hex()})
+			defer setup.ctrl.Finish()
+			if tt.prep != nil {
+				tt.prep(setup)
+			}
+
+			setup.router.VerifyEmail(setup.testCtx)
 
 			assert.Equal(t, tt.wantResCode, setup.w.Code)
 		})

--- a/routers/frontend/routes.go
+++ b/routers/frontend/routes.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"encoding/json"
+	"github.com/unicsmcr/hs_auth/config/role"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
 	"net/http"
 	"time"
@@ -221,7 +222,7 @@ func (r *frontendRouter) Register(ctx *gin.Context) {
 		return
 	}
 
-	user, err := r.userService.CreateUser(ctx, name, email, password)
+	user, err := r.userService.CreateUser(ctx, name, email, password, role.Unverified)
 	if err != nil {
 		switch err {
 		case services.ErrEmailTaken:
@@ -472,7 +473,7 @@ func (r *frontendRouter) VerifyEmail(ctx *gin.Context) {
 		r.logger.Error("could not update user", zap.Error(err))
 		ctx.HTML(http.StatusInternalServerError, "login.gohtml", templateDataModel{
 			Cfg: r.cfg,
-			Err: "Something went wrong",})
+			Err: "Something went wrong"})
 		return
 	}
 
@@ -667,17 +668,17 @@ func (r *frontendRouter) VerifyEmailResend(ctx *gin.Context) {
 			r.logger.Debug("invalid token")
 			ctx.HTML(http.StatusUnauthorized, "login.gohtml", templateDataModel{
 				Cfg: r.cfg,
-				Err: "Invalid token",})
+				Err: "Invalid token"})
 		case services.ErrNotFound:
 			r.logger.Debug("user not found")
 			ctx.HTML(http.StatusBadRequest, "login.gohtml", templateDataModel{
 				Cfg: r.cfg,
-				Err: "Could not find user",})
+				Err: "Could not find user"})
 		default:
 			r.logger.Error("could not find user with jwt", zap.Error(err))
 			ctx.HTML(http.StatusInternalServerError, "login.gohtml", templateDataModel{
 				Cfg: r.cfg,
-				Err: "Something went wrong",})
+				Err: "Something went wrong"})
 		}
 		return
 	}
@@ -687,7 +688,7 @@ func (r *frontendRouter) VerifyEmailResend(ctx *gin.Context) {
 		r.logger.Error("could not send email verification email", zap.Error(err))
 		ctx.HTML(http.StatusInternalServerError, "login.gohtml", templateDataModel{
 			Cfg: r.cfg,
-			Err: "Something went wrong",})
+			Err: "Something went wrong"})
 		return
 	}
 

--- a/routers/frontend/routes_test.go
+++ b/routers/frontend/routes_test.go
@@ -419,7 +419,7 @@ func Test_Register(t *testing.T) {
 			password:        "testtest",
 			email:           "bob@test.com",
 			prep: func(setup *testSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "bob", "bob@test.com", "testtest").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "bob", "bob@test.com", "testtest", gomock.Any()).
 					Return(nil, services.ErrEmailTaken).Times(1)
 			},
 			wantResCode: http.StatusBadRequest,
@@ -431,7 +431,7 @@ func Test_Register(t *testing.T) {
 			password:        "testtest",
 			email:           "bob@test.com",
 			prep: func(setup *testSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "bob", "bob@test.com", "testtest").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "bob", "bob@test.com", "testtest", gomock.Any()).
 					Return(nil, errors.New("service err")).Times(1)
 			},
 			wantResCode: http.StatusInternalServerError,
@@ -443,7 +443,7 @@ func Test_Register(t *testing.T) {
 			password:        "testtest",
 			email:           "bob@test.com",
 			prep: func(setup *testSetup) {
-				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "bob", "bob@test.com", "testtest").
+				setup.mockUService.EXPECT().CreateUser(gomock.Any(), "bob", "bob@test.com", "testtest", gomock.Any()).
 					Return(&entities.User{}, nil).Times(1)
 				setup.mockEService.EXPECT().SendEmailVerificationEmail(entities.User{}).
 					Return(errors.New("service err")).Times(1)
@@ -682,7 +682,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test_token",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test_token").
-					Return(&entities.User{AuthLevel:common.AuthLevel(-111)}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.AuthLevel(-111)}, nil).Times(1)
 			},
 			wantResCode: http.StatusUnauthorized,
 		},
@@ -691,7 +691,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test_token",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test_token").
-					Return(&entities.User{AuthLevel:common.Unverified + 1}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.Unverified + 1}, nil).Times(1)
 			},
 			wantResCode: http.StatusBadRequest,
 		},
@@ -700,7 +700,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test_token",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test_token").
-					Return(&entities.User{AuthLevel:common.Unverified}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.Unverified}, nil).Times(1)
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), primitive.NilObjectID.Hex(), services.UserUpdateParams{
 					entities.UserAuthLevel: common.Applicant,
 				}).Return(errors.New("service err")).Times(1)
@@ -712,7 +712,7 @@ func Test_VerifyEmail(t *testing.T) {
 			jwt:  "test_token",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().GetUserWithJWT(gomock.Any(), "test_token").
-					Return(&entities.User{AuthLevel:common.Unverified}, nil).Times(1)
+					Return(&entities.User{AuthLevel: common.Unverified}, nil).Times(1)
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), primitive.NilObjectID.Hex(), services.UserUpdateParams{
 					entities.UserAuthLevel: common.Applicant,
 				}).Return(nil).Times(1)
@@ -974,36 +974,36 @@ func Test_UpdateUser(t *testing.T) {
 		wantResCode    int
 	}{
 		{
-			name: "should return 400 when no userID is provided",
+			name:        "should return 400 when no userID is provided",
 			wantResCode: http.StatusBadRequest,
 		},
 		{
-			name: "should return 400 when paramsToUpdate is not map[entities.UserField]string",
-			wantResCode: http.StatusBadRequest,
-			userID: "test id",
+			name:           "should return 400 when paramsToUpdate is not map[entities.UserField]string",
+			wantResCode:    http.StatusBadRequest,
+			userID:         "test id",
 			paramsToUpdate: "{\"auth_level\":3}",
 		},
 		{
-			name: "should return 400 when paramsToUpdate cannot be built to services.UserUpdateParams",
-			wantResCode: http.StatusBadRequest,
-			userID: "test id",
+			name:           "should return 400 when paramsToUpdate cannot be built to services.UserUpdateParams",
+			wantResCode:    http.StatusBadRequest,
+			userID:         "test id",
 			paramsToUpdate: "{\"auth_level\":\"not a number\"}",
 		},
 		{
-			name: "should return 400 when paramsToUpdate include password",
-			wantResCode: http.StatusBadRequest,
-			userID: "test id",
+			name:           "should return 400 when paramsToUpdate include password",
+			wantResCode:    http.StatusBadRequest,
+			userID:         "test id",
 			paramsToUpdate: "{\"password\":\"not a number\"}",
 		},
 		{
-			name: "should return 400 when paramsToUpdate include _id",
-			wantResCode: http.StatusBadRequest,
-			userID: "test id",
+			name:           "should return 400 when paramsToUpdate include _id",
+			wantResCode:    http.StatusBadRequest,
+			userID:         "test id",
 			paramsToUpdate: "{\"_id\":\"not a number\"}",
 		},
 		{
-			name: "should return 400 when user service returns ErrInvalidID",
-			userID: "test id",
+			name:           "should return 400 when user service returns ErrInvalidID",
+			userID:         "test id",
 			paramsToUpdate: "{\"name\":\"Rob the Tester\"}",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), "test id", gomock.Any()).
@@ -1012,8 +1012,8 @@ func Test_UpdateUser(t *testing.T) {
 			wantResCode: http.StatusBadRequest,
 		},
 		{
-			name: "should return 400 when user service returns ErrInvalidID",
-			userID: "test id",
+			name:           "should return 400 when user service returns ErrInvalidID",
+			userID:         "test id",
 			paramsToUpdate: "{\"name\":\"Rob the Tester\"}",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), "test id", gomock.Any()).
@@ -1022,8 +1022,8 @@ func Test_UpdateUser(t *testing.T) {
 			wantResCode: http.StatusBadRequest,
 		},
 		{
-			name: "should return 500 when user service returns unknown error",
-			userID: "test id",
+			name:           "should return 500 when user service returns unknown error",
+			userID:         "test id",
 			paramsToUpdate: "{\"name\":\"Rob the Tester\"}",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), "test id", gomock.Any()).
@@ -1032,8 +1032,8 @@ func Test_UpdateUser(t *testing.T) {
 			wantResCode: http.StatusInternalServerError,
 		},
 		{
-			name: "should return 200 when updating user succeeds",
-			userID: "test id",
+			name:           "should return 200 when updating user succeeds",
+			userID:         "test id",
 			paramsToUpdate: "{\"name\":\"Rob the Tester\"}",
 			prep: func(setup *testSetup) {
 				setup.mockUService.EXPECT().UpdateUserWithID(gomock.Any(), "test id", services.UserUpdateParams{

--- a/services/emailServiceV2.go
+++ b/services/emailServiceV2.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+	"context"
+	"github.com/unicsmcr/hs_auth/entities"
+)
+
+// EmailServiceV2 is used to send out emails
+type EmailServiceV2 interface {
+	SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error
+
+	SendEmailVerificationEmail(user entities.User, emailVerificationResourcePath string) error
+	SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string, emailVerificationResourcePath string) error
+
+	SendPasswordResetEmail(user entities.User, passwordResetResourcePath string) error
+	SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResourcePath string) error
+}

--- a/services/emailServiceV2.go
+++ b/services/emailServiceV2.go
@@ -13,5 +13,4 @@ type EmailServiceV2 interface {
 	SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources []common.UniformResourceIdentifier) error
 
 	SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources []common.UniformResourceIdentifier) error
-	SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResources []common.UniformResourceIdentifier) error
 }

--- a/services/emailServiceV2.go
+++ b/services/emailServiceV2.go
@@ -10,7 +10,7 @@ import (
 type EmailServiceV2 interface {
 	SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error
 
-	SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources []common.UniformResourceIdentifier) error
+	SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources common.UniformResourceIdentifiers) error
 
-	SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources []common.UniformResourceIdentifier) error
+	SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources common.UniformResourceIdentifiers) error
 }

--- a/services/emailServiceV2.go
+++ b/services/emailServiceV2.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"github.com/unicsmcr/hs_auth/authorization/v2/common"
 	"github.com/unicsmcr/hs_auth/entities"
 )
 
@@ -9,9 +10,8 @@ import (
 type EmailServiceV2 interface {
 	SendEmail(subject, htmlBody, plainTextBody, senderName, senderEmail, recipientName, recipientEmail string) error
 
-	SendEmailVerificationEmail(user entities.User, emailVerificationResourcePath string) error
-	SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string, emailVerificationResourcePath string) error
+	SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources []common.UniformResourceIdentifier) error
 
-	SendPasswordResetEmail(user entities.User, passwordResetResourcePath string) error
-	SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResourcePath string) error
+	SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources []common.UniformResourceIdentifier) error
+	SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResources []common.UniformResourceIdentifier) error
 }

--- a/services/mongo/userService.go
+++ b/services/mongo/userService.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"github.com/unicsmcr/hs_auth/config/role"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -35,7 +36,7 @@ func NewMongoUserService(logger *zap.Logger, env *environment.Env, cfg *config.A
 	}
 }
 
-func (s *mongoUserService) CreateUser(ctx context.Context, name, email, password string) (*entities.User, error) {
+func (s *mongoUserService) CreateUser(ctx context.Context, name, email, password string, role role.UserRole) (*entities.User, error) {
 	formattedEmail := strings.ToLower(email)
 
 	// check if email is not taken
@@ -62,6 +63,7 @@ func (s *mongoUserService) CreateUser(ctx context.Context, name, email, password
 		Email:     formattedEmail,
 		Password:  pwdHash,
 		AuthLevel: s.cfg.BaseAuthLevel,
+		Role:      role,
 	}
 
 	_, err = s.userRepository.InsertOne(ctx, *user)

--- a/services/mongo/userService_test.go
+++ b/services/mongo/userService_test.go
@@ -4,6 +4,7 @@ package mongo
 
 import (
 	"context"
+	"github.com/unicsmcr/hs_auth/config/role"
 	"strings"
 	"testing"
 	"time"
@@ -182,7 +183,7 @@ func Test_CreateUser__should_return_ErrEmailTaken_when_email_is_taken(t *testing
 	_, err := uRepo.InsertOne(context.Background(), testUser)
 	assert.NoError(t, err)
 
-	user, err := uService.CreateUser(context.Background(), testUser.Name, testUser.Email, testUser.Password)
+	user, err := uService.CreateUser(context.Background(), testUser.Name, testUser.Email, testUser.Password, role.Applicant)
 
 	assert.Equal(t, services.ErrEmailTaken, err)
 	assert.Nil(t, user)
@@ -197,7 +198,7 @@ func Test_CreateUser__should_create_correct_user(t *testing.T) {
 	testUser2.Email = "TesT2@emaiL.CoM"
 	testUser2FormattedEmail := "test2@email.com"
 
-	user, err := uService.CreateUser(context.Background(), testUser2.Name, testUser2.Email, testUser2.Password)
+	user, err := uService.CreateUser(context.Background(), testUser2.Name, testUser2.Email, testUser2.Password, role.Applicant)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testUser2.Name, user.Name)
@@ -207,6 +208,7 @@ func Test_CreateUser__should_create_correct_user(t *testing.T) {
 		string(entities.UserEmail):     testUser2FormattedEmail,
 		string(entities.UserName):      testUser2.Name,
 		string(entities.UserAuthLevel): testBaseAuthLevel,
+		string(entities.UserRole):      role.Applicant,
 	})
 
 	assert.NoError(t, res.Err())

--- a/services/sendgrid/emailService.go
+++ b/services/sendgrid/emailService.go
@@ -113,7 +113,7 @@ func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User) er
 	}
 
 	return s.SendEmail(
-		s.cfg.Email.EmailVerficationEmailSubj,
+		s.cfg.Email.EmailVerificationEmailSubj,
 		contentBuff.String(),
 		contentBuff.String(),
 		s.cfg.Email.NoreplyEmailName,

--- a/services/sendgrid/emailService_test.go
+++ b/services/sendgrid/emailService_test.go
@@ -54,7 +54,7 @@ func Test_NewSendgridEmailService__should_return_error_when_template_path_is_inc
 	passwordResetEmailTemplatePath = "invalid path"
 	emailVerifyEmailTemplatePath = _testEmailTemplate
 
-	service, err := NewSendgridEmailService(nil, nil, nil,nil, nil)
+	service, err := NewSendgridEmailService(nil, nil, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, service)
 
@@ -123,9 +123,9 @@ func Test_SendEmailVerificationEmail__should_not_return_error_when_sending_email
 
 	service, err := NewSendgridEmailService(zap.NewNop(), &config.AppConfig{
 		Email: config.EmailConfig{
-			NoreplyEmailAddr:          "bob@test.com",
-			NoreplyEmailName:          "Bob the Tester",
-			EmailVerficationEmailSubj: "test subject",
+			NoreplyEmailAddr:           "bob@test.com",
+			NoreplyEmailName:           "Bob the Tester",
+			EmailVerificationEmailSubj: "test subject",
 		},
 	}, env, client, nil)
 	assert.NoError(t, err)
@@ -188,9 +188,9 @@ func Test_SendPasswordResetEmail__should_not_return_error_when_sending_email_is_
 
 	service, err := NewSendgridEmailService(zap.NewNop(), &config.AppConfig{
 		Email: config.EmailConfig{
-			NoreplyEmailAddr:          "bob@test.com",
-			NoreplyEmailName:          "Bob the Tester",
-			EmailVerficationEmailSubj: "test subject",
+			NoreplyEmailAddr:           "bob@test.com",
+			NoreplyEmailName:           "Bob the Tester",
+			EmailVerificationEmailSubj: "test subject",
 		},
 	}, env, client, nil)
 	assert.NoError(t, err)

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -11,7 +11,6 @@ import (
 	"github.com/unicsmcr/hs_auth/environment"
 	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/utils"
-	"go.uber.org/zap"
 	"html/template"
 	"net/http"
 )
@@ -23,7 +22,6 @@ var (
 
 type sendgridEmailService struct {
 	*sendgrid.Client
-	logger      *zap.Logger
 	cfg         *config.AppConfig
 	env         *environment.Env
 	userService services.UserService
@@ -33,7 +31,7 @@ type sendgridEmailService struct {
 	emailVerifyEmailTemplate   *template.Template
 }
 
-func NewSendgridEmailServiceV2(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env,
+func NewSendgridEmailServiceV2(cfg *config.AppConfig, env *environment.Env,
 	client *sendgrid.Client, userService services.UserService, authorizer authV2.Authorizer) (services.EmailServiceV2, error) {
 	passwordResetEmailTemplate, err := utils.LoadTemplate("password reset", passwordResetEmailTemplatePath)
 	if err != nil {
@@ -47,7 +45,6 @@ func NewSendgridEmailServiceV2(logger *zap.Logger, cfg *config.AppConfig, env *e
 
 	return &sendgridEmailService{
 		Client:                     client,
-		logger:                     logger,
 		cfg:                        cfg,
 		env:                        env,
 		userService:                userService,
@@ -64,28 +61,13 @@ func (s *sendgridEmailService) SendEmail(subject, htmlBody, plainTextBody, sende
 	response, err := s.Send(message)
 
 	if err != nil {
-		s.logger.Error("could not issue email request",
-			zap.String("subject", subject),
-			zap.String("recipient", recipientEmail),
-			zap.String("sender", senderEmail),
-			zap.Error(err))
 		return errors.Wrap(err, "could not send email request to SendGrid")
 	}
 
 	if response.StatusCode != http.StatusAccepted {
-		s.logger.Error("email request was rejected by Sendgrid",
-			zap.String("subject", subject),
-			zap.String("recipient", recipientEmail),
-			zap.String("sender", senderEmail),
-			zap.Int("response status code", response.StatusCode),
-			zap.String("response body", response.Body))
 		return services.ErrSendgridRejectedRequest
 	}
 
-	s.logger.Debug("email request sent successfully",
-		zap.String("subject", subject),
-		zap.String("recipient", recipientEmail),
-		zap.String("sender", senderEmail))
 	return nil
 }
 func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User, emailVerificationResourcePath string) error {

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -114,6 +114,3 @@ func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, u
 func (s *sendgridEmailService) SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources []common.UniformResourceIdentifier) error {
 	panic("not implemented")
 }
-func (s *sendgridEmailService) SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResources []common.UniformResourceIdentifier) error {
-	panic("not implemented")
-}

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -82,7 +82,7 @@ func (s *sendgridEmailService) SendEmail(subject, htmlBody, plainTextBody, sende
 
 	return nil
 }
-func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources []common.UniformResourceIdentifier) error {
+func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources common.UniformResourceIdentifiers) error {
 	emailToken, err := s.authorizer.CreateServiceToken(ctx, user.ID,
 		emailVerificationResources, s.timeProvider.Now().Unix()+s.cfg.Email.TokenLifetime)
 	if err != nil {
@@ -111,6 +111,6 @@ func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, u
 		user.Email)
 }
 
-func (s *sendgridEmailService) SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources []common.UniformResourceIdentifier) error {
+func (s *sendgridEmailService) SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources common.UniformResourceIdentifiers) error {
 	panic("not implemented")
 }

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -1,22 +1,19 @@
-package sendgrid
+package v2
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"github.com/pkg/errors"
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	authV2 "github.com/unicsmcr/hs_auth/authorization/v2"
 	"github.com/unicsmcr/hs_auth/config"
 	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/environment"
 	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/utils"
-	"github.com/unicsmcr/hs_auth/utils/auth"
 	"go.uber.org/zap"
 	"html/template"
 	"net/http"
-	"time"
 )
 
 var (
@@ -30,18 +27,14 @@ type sendgridEmailService struct {
 	cfg         *config.AppConfig
 	env         *environment.Env
 	userService services.UserService
+	authorizer  authV2.Authorizer
 
 	passwordResetEmailTemplate *template.Template
 	emailVerifyEmailTemplate   *template.Template
 }
 
-type emailTemplateDataModel struct {
-	EventName  string
-	Link       string
-	SenderName string
-}
-
-func NewSendgridEmailService(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env, client *sendgrid.Client, userService services.UserService) (services.EmailService, error) {
+func NewSendgridEmailServiceV2(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env,
+	client *sendgrid.Client, userService services.UserService, authorizer authV2.Authorizer) (services.EmailServiceV2, error) {
 	passwordResetEmailTemplate, err := utils.LoadTemplate("password reset", passwordResetEmailTemplatePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load password reset template")
@@ -60,6 +53,7 @@ func NewSendgridEmailService(logger *zap.Logger, cfg *config.AppConfig, env *env
 		userService:                userService,
 		passwordResetEmailTemplate: passwordResetEmailTemplate,
 		emailVerifyEmailTemplate:   emailVerifyEmailTemplate,
+		authorizer:                 authorizer,
 	}, nil
 }
 
@@ -94,72 +88,15 @@ func (s *sendgridEmailService) SendEmail(subject, htmlBody, plainTextBody, sende
 		zap.String("sender", senderEmail))
 	return nil
 }
-func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User) error {
-	emailToken, err := auth.NewJWT(user, time.Now().Unix(), s.cfg.AuthTokenLifetime, auth.Email, []byte(s.env.Get(environment.JWTSecret)))
-	if err != nil {
-		return err
-	}
-
-	verificationURL := fmt.Sprintf("http://%s/verifyemail?token=%s", s.cfg.AppURL, emailToken)
-
-	var contentBuff bytes.Buffer
-	err = s.emailVerifyEmailTemplate.Execute(&contentBuff, emailTemplateDataModel{
-		EventName:  s.cfg.Name,
-		Link:       verificationURL,
-		SenderName: s.cfg.Email.NoreplyEmailName,
-	})
-	if err != nil {
-		return errors.Wrap(err, "could not construct email")
-	}
-
-	return s.SendEmail(
-		s.cfg.Email.EmailVerficationEmailSubj,
-		contentBuff.String(),
-		contentBuff.String(),
-		s.cfg.Email.NoreplyEmailName,
-		s.cfg.Email.NoreplyEmailAddr,
-		user.Name,
-		user.Email)
+func (s *sendgridEmailService) SendEmailVerificationEmail(user entities.User, emailVerificationResourcePath string) error {
+	panic("not implemented")
 }
-func (s *sendgridEmailService) SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string) error {
-	user, err := s.userService.GetUserWithEmail(ctx, email)
-	if err != nil {
-		return err
-	}
-
-	return s.SendEmailVerificationEmail(*user)
+func (s *sendgridEmailService) SendEmailVerificationEmailForUserWithEmail(ctx context.Context, email string, emailVerificationResourcePath string) error {
+	panic("not implemented")
 }
-func (s *sendgridEmailService) SendPasswordResetEmail(user entities.User) error {
-	emailToken, err := auth.NewJWT(user, time.Now().Unix(), s.cfg.AuthTokenLifetime, auth.Email, []byte(s.env.Get(environment.JWTSecret)))
-	if err != nil {
-		return err
-	}
-
-	resetURL := fmt.Sprintf("http://%s/resetpwd?email=%s&token=%s", s.cfg.AppURL, user.Email, emailToken)
-
-	var contentBuff bytes.Buffer
-	err = s.passwordResetEmailTemplate.Execute(&contentBuff, emailTemplateDataModel{
-		Link:       resetURL,
-		SenderName: s.cfg.Email.NoreplyEmailName,
-	})
-	if err != nil {
-		return errors.Wrap(err, "could not construct email")
-	}
-
-	return s.SendEmail(
-		s.cfg.Email.PasswordResetEmailSubj,
-		contentBuff.String(),
-		contentBuff.String(),
-		s.cfg.Email.NoreplyEmailName,
-		s.cfg.Email.NoreplyEmailAddr,
-		user.Name,
-		user.Email)
+func (s *sendgridEmailService) SendPasswordResetEmail(user entities.User, passwordResetResourcePath string) error {
+	panic("not implemented")
 }
-func (s *sendgridEmailService) SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string) error {
-	user, err := s.userService.GetUserWithEmail(ctx, email)
-	if err != nil {
-		return err
-	}
-
-	return s.SendPasswordResetEmail(*user)
+func (s *sendgridEmailService) SendPasswordResetEmailForUserWithEmail(ctx context.Context, email string, passwordResetResourcePath string) error {
+	panic("not implemented")
 }

--- a/services/sendgrid/v2/emailService_test.go
+++ b/services/sendgrid/v2/emailService_test.go
@@ -1,0 +1,97 @@
+package v2
+
+import (
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	_sendgridAPIKey    = "testkey"
+	_testEmailTemplate = "../testEmailTemplate.txt"
+)
+
+type response struct {
+	message string
+	status  int
+}
+
+func getTestClient(t *testing.T, expectedRequestBody string, wantResponse response) (*sendgrid.Client, *httptest.Server) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(expectedRequestBody) != 0 {
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedRequestBody, string(body))
+		}
+		w.WriteHeader(wantResponse.status)
+		w.Write([]byte(wantResponse.message))
+	}))
+
+	req := sendgrid.GetRequest(_sendgridAPIKey, "/", server.URL)
+	req.Method = http.MethodPost
+	client := sendgrid.Client{
+		Request: req,
+	}
+
+	return &client, server
+}
+
+func Test_NewSendgridEmailService__should_return_error_when_template_path_is_incorrect(t *testing.T) {
+	// password reset
+	passwordResetEmailTemplatePath = "invalid path"
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	service, err := NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+
+	// email verify
+	emailVerifyEmailTemplatePath = "invalid path"
+	passwordResetEmailTemplatePath = _testEmailTemplate
+
+	service, err = NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+}
+
+func Test_SendEmail__should_send_correct_message_to_sendgrid(t *testing.T) {
+	passwordResetEmailTemplatePath = "../testEmailTemplate.txt"
+	emailVerifyEmailTemplatePath = "../testEmailTemplate.txt"
+
+	client, server := getTestClient(t, `{"from":{"name":"Bob the Tester","email":"bob@test.com"},"subject":"test email","personalizations":[{"to":[{"name":"Rob the Tester","email":"rob@test.com"}]}],"content":[{"type":"text/plain","value":"test email body"},{"type":"text/html","value":"test email body"}]}`,
+		response{
+			status: http.StatusAccepted,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailServiceV2(zap.NewNop(), nil, nil, client, nil, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmail("test email", "test email body", "test email body",
+		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
+
+	assert.NoError(t, err)
+}
+
+func Test_SendEmail__should_return_error_when_sendgrid_rejects_request(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusUnauthorized,
+		})
+	defer server.Close()
+
+	service, err := NewSendgridEmailServiceV2(zap.NewNop(), nil, nil, client, nil, nil)
+	assert.NoError(t, err)
+
+	err = service.SendEmail("test email", "test email body", "test email body",
+		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
+
+	assert.Error(t, err)
+}

--- a/services/sendgrid/v2/emailService_test.go
+++ b/services/sendgrid/v2/emailService_test.go
@@ -3,7 +3,6 @@ package v2
 import (
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +44,7 @@ func Test_NewSendgridEmailService__should_return_error_when_template_path_is_inc
 	passwordResetEmailTemplatePath = "invalid path"
 	emailVerifyEmailTemplatePath = _testEmailTemplate
 
-	service, err := NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
+	service, err := NewSendgridEmailServiceV2(nil, nil, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, service)
 
@@ -53,7 +52,7 @@ func Test_NewSendgridEmailService__should_return_error_when_template_path_is_inc
 	emailVerifyEmailTemplatePath = "invalid path"
 	passwordResetEmailTemplatePath = _testEmailTemplate
 
-	service, err = NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
+	service, err = NewSendgridEmailServiceV2(nil, nil, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, service)
 }
@@ -68,7 +67,7 @@ func Test_SendEmail__should_send_correct_message_to_sendgrid(t *testing.T) {
 		})
 	defer server.Close()
 
-	service, err := NewSendgridEmailServiceV2(zap.NewNop(), nil, nil, client, nil, nil)
+	service, err := NewSendgridEmailServiceV2(nil, nil, client, nil, nil)
 	assert.NoError(t, err)
 
 	err = service.SendEmail("test email", "test email body", "test email body",
@@ -87,7 +86,7 @@ func Test_SendEmail__should_return_error_when_sendgrid_rejects_request(t *testin
 		})
 	defer server.Close()
 
-	service, err := NewSendgridEmailServiceV2(zap.NewNop(), nil, nil, client, nil, nil)
+	service, err := NewSendgridEmailServiceV2(nil, nil, client, nil, nil)
 	assert.NoError(t, err)
 
 	err = service.SendEmail("test email", "test email body", "test email body",

--- a/services/sendgrid/v2/emailService_test.go
+++ b/services/sendgrid/v2/emailService_test.go
@@ -1,12 +1,27 @@
 package v2
 
 import (
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/unicsmcr/hs_auth/authorization/v2/common"
+	"github.com/unicsmcr/hs_auth/config"
+	"github.com/unicsmcr/hs_auth/entities"
+	"github.com/unicsmcr/hs_auth/environment"
+	mock_v2 "github.com/unicsmcr/hs_auth/mocks/authorization/v2"
+	mock_services "github.com/unicsmcr/hs_auth/mocks/services"
+	mock_utils "github.com/unicsmcr/hs_auth/mocks/utils"
+	"github.com/unicsmcr/hs_auth/services"
+	"github.com/unicsmcr/hs_auth/testutils"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 const (
@@ -14,9 +29,61 @@ const (
 	_testEmailTemplate = "../testEmailTemplate.txt"
 )
 
+var testUserId = primitive.NewObjectID()
+
 type response struct {
 	message string
 	status  int
+}
+
+type emailTestSetup struct {
+	ctrl             *gomock.Controller
+	emailService     services.EmailServiceV2
+	mockUService     *mock_services.MockUserService
+	mockAuthorizer   *mock_v2.MockAuthorizer
+	mockTimeProvider *mock_utils.MockTimeProvider
+	testCtx          *gin.Context
+	emailServer      *httptest.Server
+}
+
+var testCfg = config.AppConfig{
+	Email: config.EmailConfig{
+		NoreplyEmailAddr:           "bob@test.com",
+		NoreplyEmailName:           "Bob the Tester",
+		EmailVerificationEmailSubj: "test subject",
+		TokenLifetime:              1000,
+	},
+}
+
+func setupEmailTest(t *testing.T) *emailTestSetup {
+	ctrl := gomock.NewController(t)
+	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
+	mockUService := mock_services.NewMockUserService(ctrl)
+	mockTimeProvider := mock_utils.NewMockTimeProvider(ctrl)
+	testCfgCopy := testCfg
+	restore := testutils.SetEnvVars(map[string]string{
+		environment.JWTSecret: "test",
+	})
+	defer restore()
+	env := environment.NewEnv(zap.NewNop())
+	client, server := getTestClient(t, "",
+		response{
+			status: http.StatusAccepted,
+		})
+
+	emailService, _ := NewSendgridEmailServiceV2(&testCfgCopy, env, client, mockUService, mockAuthorizer, mockTimeProvider)
+	w := httptest.NewRecorder()
+	testCtx, _ := gin.CreateTestContext(w)
+
+	return &emailTestSetup{
+		ctrl:             ctrl,
+		emailService:     emailService,
+		mockUService:     mockUService,
+		mockAuthorizer:   mockAuthorizer,
+		mockTimeProvider: mockTimeProvider,
+		testCtx:          testCtx,
+		emailServer:      server,
+	}
 }
 
 func getTestClient(t *testing.T, expectedRequestBody string, wantResponse response) (*sendgrid.Client, *httptest.Server) {
@@ -44,7 +111,7 @@ func Test_NewSendgridEmailService__should_return_error_when_template_path_is_inc
 	passwordResetEmailTemplatePath = "invalid path"
 	emailVerifyEmailTemplatePath = _testEmailTemplate
 
-	service, err := NewSendgridEmailServiceV2(nil, nil, nil, nil, nil)
+	service, err := NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, service)
 
@@ -52,7 +119,7 @@ func Test_NewSendgridEmailService__should_return_error_when_template_path_is_inc
 	emailVerifyEmailTemplatePath = "invalid path"
 	passwordResetEmailTemplatePath = _testEmailTemplate
 
-	service, err = NewSendgridEmailServiceV2(nil, nil, nil, nil, nil)
+	service, err = NewSendgridEmailServiceV2(nil, nil, nil, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, service)
 }
@@ -67,7 +134,7 @@ func Test_SendEmail__should_send_correct_message_to_sendgrid(t *testing.T) {
 		})
 	defer server.Close()
 
-	service, err := NewSendgridEmailServiceV2(nil, nil, client, nil, nil)
+	service, err := NewSendgridEmailServiceV2(nil, nil, client, nil, nil, nil)
 	assert.NoError(t, err)
 
 	err = service.SendEmail("test email", "test email body", "test email body",
@@ -86,11 +153,47 @@ func Test_SendEmail__should_return_error_when_sendgrid_rejects_request(t *testin
 		})
 	defer server.Close()
 
-	service, err := NewSendgridEmailServiceV2(nil, nil, client, nil, nil)
+	service, err := NewSendgridEmailServiceV2(nil, nil, client, nil, nil, nil)
 	assert.NoError(t, err)
 
 	err = service.SendEmail("test email", "test email body", "test email body",
 		"Bob the Tester", "bob@test.com", "Rob the Tester", "rob@test.com")
 
+	assert.Error(t, err)
+}
+
+func Test_SendEmailVerificationEmail__should_not_return_error_when_sending_email_is_successful(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	setup := setupEmailTest(t)
+	defer setup.ctrl.Finish()
+	defer setup.emailServer.Close()
+	testURI, _ := common.NewURIFromString("test")
+	setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(1, 0)).Times(1)
+	setup.mockAuthorizer.EXPECT().CreateServiceToken(setup.testCtx, testUserId, []common.UniformResourceIdentifier{testURI}, int64(1001)).
+		Return("", nil).Times(1)
+
+	err := setup.emailService.SendEmailVerificationEmail(setup.testCtx, entities.User{
+		ID: testUserId,
+	}, []common.UniformResourceIdentifier{testURI})
+	assert.NoError(t, err)
+}
+
+func Test_SendEmailVerificationEmail__should_return_error_when_authorizer_returns_error(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	setup := setupEmailTest(t)
+	defer setup.ctrl.Finish()
+	defer setup.emailServer.Close()
+	testURI, _ := common.NewURIFromString("test")
+	setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(1, 0)).Times(1)
+	setup.mockAuthorizer.EXPECT().CreateServiceToken(setup.testCtx, testUserId, []common.UniformResourceIdentifier{testURI}, int64(1001)).
+		Return("", errors.New("authorizer err")).Times(1)
+
+	err := setup.emailService.SendEmailVerificationEmail(setup.testCtx, entities.User{
+		ID: testUserId,
+	}, []common.UniformResourceIdentifier{testURI})
 	assert.Error(t, err)
 }

--- a/services/userService.go
+++ b/services/userService.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"github.com/unicsmcr/hs_auth/config/role"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"strconv"
 
@@ -37,7 +38,7 @@ type UserUpdateParams map[entities.UserField]interface{}
 
 // UserService is the service for interactions with a remote users repository
 type UserService interface {
-	CreateUser(ctx context.Context, name, email, password string) (*entities.User, error)
+	CreateUser(ctx context.Context, name, email, password string, role role.UserRole) (*entities.User, error)
 
 	GetUsers(ctx context.Context) ([]entities.User, error)
 	GetUsersWithTeam(ctx context.Context, teamID string) ([]entities.User, error)

--- a/wire.go
+++ b/wire.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unicsmcr/hs_auth/routers/frontend"
 	"github.com/unicsmcr/hs_auth/services/mongo"
 	"github.com/unicsmcr/hs_auth/services/sendgrid"
+	sendgrid_v2 "github.com/unicsmcr/hs_auth/services/sendgrid/v2"
 	"github.com/unicsmcr/hs_auth/utils"
 )
 
@@ -28,6 +29,7 @@ func InitializeServer() (Server, error) {
 		mongo.NewMongoTeamService,
 		mongo.NewMongoUserService,
 		sendgrid.NewSendgridEmailService,
+		sendgrid_v2.NewSendgridEmailServiceV2,
 		repositories.NewUserRepository,
 		repositories.NewTeamRepository,
 		repositories.NewTokenRepository,

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -12,10 +12,11 @@ import (
 	"github.com/unicsmcr/hs_auth/repositories"
 	"github.com/unicsmcr/hs_auth/routers"
 	"github.com/unicsmcr/hs_auth/routers/api/v1"
-	v2_2 "github.com/unicsmcr/hs_auth/routers/api/v2"
+	v2_3 "github.com/unicsmcr/hs_auth/routers/api/v2"
 	"github.com/unicsmcr/hs_auth/routers/frontend"
 	"github.com/unicsmcr/hs_auth/services/mongo"
 	"github.com/unicsmcr/hs_auth/services/sendgrid"
+	v2_2 "github.com/unicsmcr/hs_auth/services/sendgrid/v2"
 	"github.com/unicsmcr/hs_auth/utils"
 )
 
@@ -58,7 +59,11 @@ func InitializeServer() (Server, error) {
 	}
 	tokenService := mongo.NewMongoTokenService(logger, env, tokenRepository)
 	authorizer := v2.NewAuthorizer(timeProvider, env, logger, tokenService)
-	apiv2Router := v2_2.NewAPIV2Router(logger, appConfig, authorizer, userService, teamService, tokenService, emailService, timeProvider)
+	emailServiceV2, err := v2_2.NewSendgridEmailServiceV2(appConfig, env, client, userService, authorizer, timeProvider)
+	if err != nil {
+		return Server{}, err
+	}
+	apiv2Router := v2_3.NewAPIV2Router(logger, appConfig, authorizer, userService, teamService, tokenService, emailServiceV2, timeProvider)
 	router := frontend.NewRouter(logger, appConfig, env, userService, teamService, emailService)
 	mainRouter := routers.NewMainRouter(logger, apiv1Router, apiv2Router, router)
 	server := NewServer(mainRouter, env)


### PR DESCRIPTION
Resolves #87 and #107 

Implements operations `VerifyEmail`, `ResendEmailVerification` and updates the `Register` operation to send an email verification email if email verification is enabled. Also implements an email service client that uses auth system v2 `EmailServiceV2`.

Sending an email when resetting the user's password has been temporarily disabled, it will be re-enabled in a separate PR which implements sending a password reset email through `EmailServiceV2`