### PR TITLE
feat: Performance tests API v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 go:
   - 1.13.x
 
+# Only clone the two most recent commits (used for performance tests)
 git:
   depth: 2
 
@@ -24,6 +25,8 @@ jobs:
     - stage: "Tests"
       script:
         - make ci
+      after_success:
+          - bash <(curl -s https://codecov.io/bash)
     - stage: "Benchmark"
       script:
         - cob -bench-cmd make -bench-args bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ env:
 
 jobs:
   include:
-    - stage: "Tests"
+    - name: "Test"
       script:
         - make ci
       after_success:
           - bash <(curl -s https://codecov.io/bash)
-    - stage: "Benchmark"
+    - name: "Benchmark"
       script:
         - cob -bench-cmd make -bench-args bench
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,28 @@ language: go
 go:
   - 1.13.x
 
-# Only clone the most recent commit.
 git:
-  depth: 1
+  depth: 2
 
 before_install:
+  - curl -sfL https://raw.githubusercontent.com/knqyf263/cob/master/install.sh | sudo sh -s -- -b /usr/local/bin
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - cp app.env.example app.env
   - cp mongo.env.example mongo.env
   - cp mongo_express.env.example mongo_express.env
-  - go get github.com/golang/mock/mockgen
+  - GO111MODULE=off go get github.com/golang/mock/mockgen
 
 env:
   - GO111MODULE=on
 
-script:
-  - make ci
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+jobs:
+  include:
+    - stage: "Tests"
+      script:
+        - make ci
+    - stage: "Benchmark"
+      script:
+        - cob -bench-cmd make -bench-args bench
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ ci: vet mocks
 	docker-compose -f $(test_docker_compose_file) up -d
 	go test ./... -coverprofile=coverage.txt -covermode=atomic -tags integration
 
+bench: vet mocks
+	docker-compose -f $(test_docker_compose_file) up -d
+	go test ./... -run=xxx -bench=. benchtime 30s
+
 # builds the executable
 build:
 	go build -o bin/hs_auth main.go

--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -606,3 +606,20 @@ func BenchmarkAuthorizer_GetAuthorizedResources_ServiceToken(b *testing.B) {
 		_, _ = setup.authorizer.GetAuthorizedResources(testToken, []common.UniformResourceIdentifier{createTestURI("hs:hs_application")})
 	}
 }
+
+// TODO: Uncomment once authorizer updated to check permissions of user token. See https://github.com/unicsmcr/hs_auth/issues/114
+//func BenchmarkAuthorizer_GetAuthorizedResources_UserToken(b *testing.B) {
+//	b.StopTimer()
+//
+//	jwtSecret := "test_secret"
+//	setup := setupAuthorizerBenchmarks(b, jwtSecret)
+//	defer setup.ctrl.Finish()
+//
+//	testToken, _ := setup.authorizer.CreateUserToken(testUserId, testAuthTokenLifetime+setup.timeProvider.Now().Unix())
+//
+//	b.StartTimer()
+//
+//	for n := 0; n < b.N; n++ {
+//		_, _ = setup.authorizer.GetAuthorizedResources(testToken, []common.UniformResourceIdentifier{createTestURI("hs:hs_application")})
+//	}
+//}

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/unicsmcr/hs_auth/services/mongo"
 	"github.com/unicsmcr/hs_auth/utils"
 	mongod "go.mongodb.org/mongo-driver/mongo"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -209,7 +208,7 @@ func addBenchmarkDataToDB(db *mongod.Database) error {
 		}
 
 		userTeam := primitive.ObjectID{}
-		if currentTestTeamCount == 0 || rand.Float64() > 0.4 {
+		if currentTestTeamCount == 0 || len(testTeams) < usersToAdd/10 {
 			userTeam = currentTestTeamID
 			currentTestTeamCount++
 		}

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	v2 "github.com/unicsmcr/hs_auth/authorization/v2"
 	"github.com/unicsmcr/hs_auth/environment"
 	"github.com/unicsmcr/hs_auth/repositories"
 	"github.com/unicsmcr/hs_auth/services/mongo"
@@ -115,6 +116,8 @@ func setupUsersTest(t *testing.T) *usersTestSetup {
 }
 
 func setupUserBenchmark(b *testing.B) *usersBenchmarkSetup {
+	// Prevents gin from spamming the console output
+	// Required for 'cob' benchmark result parser to work correctly
 	gin.SetMode(gin.ReleaseMode)
 
 	db := testutils.ConnectToIntegrationTestDB(b)

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -1,8 +1,13 @@
 package v2
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"github.com/unicsmcr/hs_auth/environment"
+	"github.com/unicsmcr/hs_auth/repositories"
+	"github.com/unicsmcr/hs_auth/services/mongo"
+	"github.com/unicsmcr/hs_auth/utils"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,6 +51,18 @@ type usersTestSetup struct {
 	w                *httptest.ResponseRecorder
 }
 
+type usersBenchmarkSetup struct {
+	ctrl         *gomock.Controller
+	router       APIV2Router
+	timeProvider utils.TimeProvider
+	testUser     *entities.User
+	testCtx      *gin.Context
+	w            *httptest.ResponseRecorder
+	authorizer   v2.Authorizer
+	uRepo        *repositories.UserRepository
+	cleanup      func()
+}
+
 func setupUsersTest(t *testing.T) *usersTestSetup {
 	ctrl := gomock.NewController(t)
 	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
@@ -80,6 +97,64 @@ func setupUsersTest(t *testing.T) *usersTestSetup {
 		testUser:         &testUser,
 		testCtx:          testCtx,
 		w:                w,
+	}
+}
+
+func setupUserBenchmark(b *testing.B) *usersBenchmarkSetup {
+	gin.SetMode(gin.ReleaseMode)
+
+	db := testutils.ConnectToIntegrationTestDB(b)
+
+	userRepository, err := repositories.NewUserRepository(db)
+	if err != nil {
+		panic(err)
+	}
+	tokenRepository, err := repositories.NewTokenRepository(db)
+	if err != nil {
+		panic(err)
+	}
+	resetEnv := testutils.SetEnvVars(map[string]string{
+		environment.JWTSecret: "supersecret",
+	})
+	env := environment.NewEnv(zap.NewNop())
+	resetEnv()
+
+	tokenService := mongo.NewMongoTokenService(zap.NewNop(), env, tokenRepository)
+	userService := mongo.NewMongoUserService(zap.NewNop(), env, &config.AppConfig{
+		AuthTokenLifetime: testAuthTokenLifetime,
+	}, userRepository)
+
+	ctrl := gomock.NewController(b)
+	timeProvider := utils.NewTimeProvider()
+	authorizer := v2.NewAuthorizer(timeProvider, env, zap.NewNop(), tokenService)
+	router := NewAPIV2Router(zap.NewNop(), &config.AppConfig{
+		AuthTokenLifetime: testAuthTokenLifetime,
+	}, authorizer, userService, nil, tokenService, nil, timeProvider)
+
+	w := httptest.NewRecorder()
+	testCtx, _ := gin.CreateTestContext(w)
+
+	testUser := entities.User{
+		ID:       testUserId,
+		Name:     "Bob the Tester",
+		Email:    "test@email.com",
+		Password: "password123",
+		Team:     primitive.NewObjectID(),
+	}
+
+	return &usersBenchmarkSetup{
+		ctrl:         ctrl,
+		router:       router,
+		timeProvider: timeProvider,
+		testCtx:      testCtx,
+		testUser:     &testUser,
+		w:            w,
+		authorizer:   authorizer,
+		uRepo:        userRepository,
+		cleanup: func() {
+			_ = userRepository.Drop(context.Background())
+			_ = tokenRepository.Drop(context.Background())
+		},
 	}
 }
 
@@ -1075,5 +1150,29 @@ func TestApiV2Router_GetPasswordResetEmail(t *testing.T) {
 
 			assert.Equal(t, tt.wantResCode, setup.w.Code)
 		})
+	}
+}
+
+func BenchmarkApiV2Router_GetUser(b *testing.B) {
+	b.StopTimer()
+
+	setup := setupUserBenchmark(b)
+	defer setup.cleanup()
+	defer setup.ctrl.Finish()
+
+	_, err := setup.uRepo.InsertOne(context.Background(), setup.testUser)
+	if err != nil {
+		panic(err)
+	}
+	testToken, _ := setup.authorizer.CreateUserToken(testUserId, testAuthTokenLifetime+setup.timeProvider.Now().Unix())
+
+	testutils.AddRequestWithFormParamsToCtx(setup.testCtx, http.MethodGet, nil)
+	setup.testCtx.Request.Header.Set(authTokenHeader, testToken)
+	testutils.AddUrlParamsToCtx(setup.testCtx, map[string]string{"id": "me"})
+
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		setup.router.GetUser(setup.testCtx)
 	}
 }

--- a/testutils/testDB.go
+++ b/testutils/testDB.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,7 @@ const dbDatabase = "hs_auth"
 
 // ConnectToIntegrationTestDB waits for the integrations tests DB to become available
 // and returns a connection to the DB
-func ConnectToIntegrationTestDB(t *testing.T) *mongo.Database {
+func ConnectToIntegrationTestDB(t assert.TestingT) *mongo.Database {
 	client, err := mongo.NewClient(options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s/%s", dbUser, dbPassword, dbAddress, dbDatabase)))
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Resolves #101 

The TravisCI `PR` build will fail for this PR, all following PRs will work as expected.

This PR adds performance tests to some of the most common/important routes in the v2 API. It also uses [cob](https://github.com/knqyf263/cob) to compare the performance of `HEAD` and `HEAD~1` commits.

Below is a list of the endpoints that have benchmarks implemented:

- [x] GetUser
- [x] User Token Check
- [x] Service Token Check 

_Note:_ The benchmark results reported by cob will be different than results we see locally, the CI machines are probably much more powerful than local machines.