### PR TITLE
feat: Update GetPasswordResetEmail to use EmailService V2

### DIFF
--- a/authorization/v2/authorizer.go
+++ b/authorization/v2/authorizer.go
@@ -102,6 +102,10 @@ func (a *authorizer) InvalidateServiceToken(ctx context.Context, token string) e
 		return errors.Wrap(common.ErrInvalidToken, err.Error())
 	}
 
+	if claims.TokenType != Service {
+		return errors.Wrap(common.ErrInvalidTokenType, "only service tokens can be invalidated")
+	}
+
 	return a.tokenService.DeleteServiceToken(ctx, claims.Id)
 }
 

--- a/authorization/v2/authorizer_test.go
+++ b/authorization/v2/authorizer_test.go
@@ -191,6 +191,16 @@ func TestAuthorizer_InvalidateServiceToken__should_return_error_when_token_is_in
 	assert.Error(t, err)
 }
 
+func TestAuthorizer_InvalidateServiceToken__should_return_error_when_token_type_is_not_service(t *testing.T) {
+	jwtSecret := "test_secret"
+	token := createToken(t, "test_id", nil, 1000, User, jwtSecret)
+	setup := setupAuthorizerTests(t, jwtSecret)
+	defer setup.ctrl.Finish()
+
+	err := setup.authorizer.InvalidateServiceToken(setup.testCtx, token)
+	assert.Equal(t, common.ErrInvalidTokenType, errors.Cause(err))
+}
+
 func TestAuthorizer_CreateServiceToken_throws_unknown_error(t *testing.T) {
 	testID := primitive.NewObjectID()
 	var testTTL int64 = 100

--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -582,7 +582,7 @@ func (r *apiV2Router) makeEmailVerificationURIs(user entities.User) (common.Unif
 func (r *apiV2Router) makePasswordResetURIs(user entities.User) (common.UniformResourceIdentifiers, error) {
 	apiUri, err := common.NewURIFromString(fmt.Sprintf("%s:SetPassword?path_id=%s", r.GetResourcePath(), user.ID.Hex()))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create URI for API email verification resource")
+		return nil, errors.Wrap(err, "could not create URI for API password reset resource")
 	}
 
 	// TODO: add resource for frontend password reset (https://github.com/unicsmcr/hs_auth/issues/106)

--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -362,6 +362,12 @@ func (r *apiV2Router) SetPassword(ctx *gin.Context) {
 	}
 
 	ctx.Status(http.StatusOK)
+
+	err = r.authorizer.InvalidateServiceToken(ctx, r.GetAuthToken(ctx))
+	if err != nil &&
+		err != common.ErrInvalidTokenType { // ignoring error when operation was not called with a service token
+		r.logger.Warn("could not invalidate token after changing user's password", zap.Error(err))
+	}
 }
 
 // GET: /api/v2/users/(:id|me)/password/resetEmail

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -1190,43 +1190,43 @@ func TestApiV2Router_GetPasswordResetEmail(t *testing.T) {
 			wantResCode: http.StatusInternalServerError,
 		},
 		// TODO: uncomment tests when password reset is integrated with email service v2
-		//{
-		//	name:   "should return 500 when user id is me and mail_service_returns_error",
-		//	userId: "me",
-		//	prep: func(setup *usersTestSetup) {
-		//		setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
-		//			Return(testUserId, nil).Times(1)
-		//		setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
-		//			Return(setup.testUser, nil).Times(1)
-		//		setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
-		//			Return(errors.New("random error")).Times(1)
-		//	},
-		//	wantResCode: http.StatusInternalServerError,
-		//},
-		//{
-		//	name:   "should return 200 when user id is me",
-		//	userId: "me",
-		//	prep: func(setup *usersTestSetup) {
-		//		setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
-		//			Return(testUserId, nil).Times(1)
-		//		setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
-		//			Return(setup.testUser, nil).Times(1)
-		//		setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
-		//			Return(nil).Times(1)
-		//	},
-		//	wantResCode: http.StatusOK,
-		//},
-		//{
-		//	name:   "should return 200 when user id is specified",
-		//	userId: testUserId.Hex(),
-		//	prep: func(setup *usersTestSetup) {
-		//		setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
-		//			Return(setup.testUser, nil).Times(1)
-		//		setup.mockEService.EXPECT().SendPasswordResetEmail(*setup.testUser).
-		//			Return(nil).Times(1)
-		//	},
-		//	wantResCode: http.StatusOK,
-		//},
+		{
+			name:   "should return 500 when user id is me and email service returns error",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(setup.testUser, nil).Times(1)
+				setup.mockEService.EXPECT().SendPasswordResetEmail(setup.testCtx, *setup.testUser, gomock.Any()).
+					Return(errors.New("random error")).Times(1)
+			},
+			wantResCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "should return 200 when user id is me",
+			userId: "me",
+			prep: func(setup *usersTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetUserIdFromToken(testAuthToken).
+					Return(testUserId, nil).Times(1)
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(setup.testUser, nil).Times(1)
+				setup.mockEService.EXPECT().SendPasswordResetEmail(setup.testCtx, *setup.testUser, gomock.Any()).
+					Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+		{
+			name:   "should return 200 when user id is specified",
+			userId: testUserId.Hex(),
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().GetUserWithID(setup.testCtx, testUserId.Hex()).
+					Return(setup.testUser, nil).Times(1)
+				setup.mockEService.EXPECT().SendPasswordResetEmail(setup.testCtx, *setup.testUser, gomock.Any()).
+					Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {

--- a/routers/api/v2/users_test.go
+++ b/routers/api/v2/users_test.go
@@ -1102,6 +1102,8 @@ func TestApiV2Router_SetPassword(t *testing.T) {
 					Return(testUserId, nil).Times(1)
 				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), gomock.Any()).
 					Return(nil).Times(1)
+				setup.mockAuthorizer.EXPECT().InvalidateServiceToken(setup.testCtx, testAuthToken).
+					Return(nil).Times(1)
 			},
 			wantResCode: http.StatusOK,
 		},
@@ -1112,6 +1114,20 @@ func TestApiV2Router_SetPassword(t *testing.T) {
 			prep: func(setup *usersTestSetup) {
 				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), gomock.Any()).
 					Return(nil).Times(1)
+				setup.mockAuthorizer.EXPECT().InvalidateServiceToken(setup.testCtx, testAuthToken).
+					Return(nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+		},
+		{
+			name:     "should return 200 when invalidating service token fails",
+			userId:   testUserId.Hex(),
+			password: "test",
+			prep: func(setup *usersTestSetup) {
+				setup.mockUService.EXPECT().UpdateUserWithID(setup.testCtx, testUserId.Hex(), gomock.Any()).
+					Return(nil).Times(1)
+				setup.mockAuthorizer.EXPECT().InvalidateServiceToken(setup.testCtx, testAuthToken).
+					Return(common.ErrInvalidToken).Times(1)
 			},
 			wantResCode: http.StatusOK,
 		},

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -104,6 +104,7 @@ func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, u
 	return s.SendEmail(
 		s.cfg.Email.EmailVerificationEmailSubj,
 		contentBuff.String(),
+		// TODO: plaintext should not be the same as HTML (https://github.com/unicsmcr/hs_auth/issues/120)
 		contentBuff.String(),
 		s.cfg.Email.NoreplyEmailName,
 		s.cfg.Email.NoreplyEmailAddr,
@@ -132,6 +133,7 @@ func (s *sendgridEmailService) SendPasswordResetEmail(ctx context.Context, user 
 	return s.SendEmail(
 		s.cfg.Email.PasswordResetEmailSubj,
 		contentBuff.String(),
+		// TODO: plaintext should not be the same as HTML (https://github.com/unicsmcr/hs_auth/issues/120)
 		contentBuff.String(),
 		s.cfg.Email.NoreplyEmailName,
 		s.cfg.Email.NoreplyEmailAddr,

--- a/services/sendgrid/v2/emailService.go
+++ b/services/sendgrid/v2/emailService.go
@@ -83,6 +83,7 @@ func (s *sendgridEmailService) SendEmail(subject, htmlBody, plainTextBody, sende
 	return nil
 }
 func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, user entities.User, emailVerificationResources common.UniformResourceIdentifiers) error {
+	// TODO: the emails should use tokens of type "email" (https://github.com/unicsmcr/hs_auth/issues/121)
 	emailToken, err := s.authorizer.CreateServiceToken(ctx, user.ID,
 		emailVerificationResources, s.timeProvider.Now().Unix()+s.cfg.Email.TokenLifetime)
 	if err != nil {
@@ -113,6 +114,7 @@ func (s *sendgridEmailService) SendEmailVerificationEmail(ctx context.Context, u
 }
 
 func (s *sendgridEmailService) SendPasswordResetEmail(ctx context.Context, user entities.User, passwordResetResources common.UniformResourceIdentifiers) error {
+	// TODO: the emails should use tokens of type "email" (https://github.com/unicsmcr/hs_auth/issues/1210
 	emailToken, err := s.authorizer.CreateServiceToken(ctx, user.ID,
 		passwordResetResources, s.timeProvider.Now().Unix()+s.cfg.Email.TokenLifetime)
 	if err != nil {

--- a/services/sendgrid/v2/emailService_test.go
+++ b/services/sendgrid/v2/emailService_test.go
@@ -197,3 +197,39 @@ func Test_SendEmailVerificationEmail__should_return_error_when_authorizer_return
 	}, []common.UniformResourceIdentifier{testURI})
 	assert.Error(t, err)
 }
+
+func Test_SendPasswordResetEmail__should_not_return_error_when_sending_email_is_successful(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	setup := setupEmailTest(t)
+	defer setup.ctrl.Finish()
+	defer setup.emailServer.Close()
+	testURI, _ := common.NewURIFromString("test")
+	setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(1, 0)).Times(1)
+	setup.mockAuthorizer.EXPECT().CreateServiceToken(setup.testCtx, testUserId, []common.UniformResourceIdentifier{testURI}, int64(1001)).
+		Return("", nil).Times(1)
+
+	err := setup.emailService.SendPasswordResetEmail(setup.testCtx, entities.User{
+		ID: testUserId,
+	}, []common.UniformResourceIdentifier{testURI})
+	assert.NoError(t, err)
+}
+
+func Test_SendPasswordResetEmail__should_return_error_when_authorizer_returns_error(t *testing.T) {
+	passwordResetEmailTemplatePath = _testEmailTemplate
+	emailVerifyEmailTemplatePath = _testEmailTemplate
+
+	setup := setupEmailTest(t)
+	defer setup.ctrl.Finish()
+	defer setup.emailServer.Close()
+	testURI, _ := common.NewURIFromString("test")
+	setup.mockTimeProvider.EXPECT().Now().Return(time.Unix(1, 0)).Times(1)
+	setup.mockAuthorizer.EXPECT().CreateServiceToken(setup.testCtx, testUserId, []common.UniformResourceIdentifier{testURI}, int64(1001)).
+		Return("", errors.New("authorizer err")).Times(1)
+
+	err := setup.emailService.SendPasswordResetEmail(setup.testCtx, entities.User{
+		ID: testUserId,
+	}, []common.UniformResourceIdentifier{testURI})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
For issue #118 

Updates the `GetPasswordResetEmail` to use `EmailServiceV2` to send out the password reset email.