### PR TITLE
 feat: Migrate frontend Register to auth V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.4.0
-	github.com/go-redis/redis/v7 v7.0.0-beta.4
+	github.com/go-redis/redis/v7 v7.0.0-beta.4 // indirect
 	github.com/golang/mock v1.4.3
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/wire v0.4.0
@@ -22,9 +22,10 @@ require (
 	go.mongodb.org/mongo-driver v1.1.1
 	go.uber.org/config v1.3.1
 	go.uber.org/zap v1.10.0
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/text v0.3.2 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1
+	golang.org/x/tools v0.0.0-20201014170642-d1624618ad65
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 )
 
 replace github.com/ugorji/go v1.1.4 => github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.1.1 h1:Sq1fR+0c58RME5EoqKdjkiQAmPjmfHlZOoRI6fTUOcs=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -184,10 +185,13 @@ golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsu
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -201,6 +205,8 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -209,6 +215,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -221,6 +229,8 @@ golang.org/x/sys v0.0.0-20190515120540-06a5c4944438 h1:khxRGsvPk4n2y8I/mLLjp7e5d
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -236,10 +246,13 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e h1:ssd5ulOvVWlh4kDSUF2SqzmMeWfjmwDXM+uGw/aQjRE=
 golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20201014170642-d1624618ad65 h1:q80OtYaeeySe8Kqg0vjXehHwj5fUTqe3xOvnbi5w3Gg=
+golang.org/x/tools v0.0.0-20201014170642-d1624618ad65/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/routers/api/v2/router.go
+++ b/routers/api/v2/router.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	common2 "github.com/unicsmcr/hs_auth/routers/common"
 	"net/http"
 
 	"github.com/unicsmcr/hs_auth/authorization/v2/common"
@@ -15,7 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const resourcePath = "hs:hs_auth:api:v2"
 const authTokenHeader = "Authorization"
 
 type APIV2Router interface {
@@ -96,7 +96,7 @@ func (r *apiV2Router) RegisterRoutes(routerGroup *gin.RouterGroup) {
 }
 
 func (r *apiV2Router) GetResourcePath() string {
-	return resourcePath
+	return common2.ApiV2ResourcePath
 }
 
 func (r *apiV2Router) GetAuthToken(ctx *gin.Context) string {

--- a/routers/api/v2/router_test.go
+++ b/routers/api/v2/router_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/unicsmcr/hs_auth/authorization/v2/common"
 	"github.com/unicsmcr/hs_auth/config"
+	common2 "github.com/unicsmcr/hs_auth/routers/common"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -156,7 +157,7 @@ func TestApiV2Router_RegisterRoutes(t *testing.T) {
 
 func TestApiV2Router_GetResourcePath(t *testing.T) {
 	router := &apiV2Router{}
-	assert.Equal(t, "hs:hs_auth:api:v2", router.GetResourcePath())
+	assert.Equal(t, common2.ApiV2ResourcePath, router.GetResourcePath())
 }
 
 func TestApiV2Router_GetAuthToken(t *testing.T) {

--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -8,7 +8,7 @@ import (
 	"github.com/unicsmcr/hs_auth/config/role"
 	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
-	common2 "github.com/unicsmcr/hs_auth/routers/common"
+	rcommon "github.com/unicsmcr/hs_auth/routers/common"
 	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/utils/auth"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -104,7 +104,7 @@ func (r *apiV2Router) Register(ctx *gin.Context) {
 	ctx.Status(http.StatusOK)
 
 	if r.cfg.Auth.EmailVerificationRequired {
-		err = r.emailService.SendEmailVerificationEmail(ctx, *user, common2.MakeEmailVerificationURIs(*user))
+		err = r.emailService.SendEmailVerificationEmail(ctx, *user, rcommon.MakeEmailVerificationURIs(*user))
 		if err != nil {
 			r.logger.Warn("could not send email verification email", zap.Error(err))
 		}
@@ -390,7 +390,7 @@ func (r *apiV2Router) GetPasswordResetEmail(ctx *gin.Context) {
 		return
 	}
 
-	err = r.emailService.SendPasswordResetEmail(ctx, *user, common2.MakePasswordResetURIs(*user))
+	err = r.emailService.SendPasswordResetEmail(ctx, *user, rcommon.MakePasswordResetURIs(*user))
 	if err != nil {
 		r.logger.Error("could send password reset email", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
@@ -537,7 +537,7 @@ func (r *apiV2Router) ResendEmailVerification(ctx *gin.Context) {
 		return
 	}
 
-	err = r.emailService.SendEmailVerificationEmail(ctx, *user, common2.MakeEmailVerificationURIs(*user))
+	err = r.emailService.SendEmailVerificationEmail(ctx, *user, rcommon.MakeEmailVerificationURIs(*user))
 	if err != nil {
 		r.logger.Error("could send email verification email", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")

--- a/routers/api/v2/users.go
+++ b/routers/api/v2/users.go
@@ -2,13 +2,13 @@ package v2
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"github.com/unicsmcr/hs_auth/authorization/v2/common"
 	"github.com/unicsmcr/hs_auth/config/role"
 	"github.com/unicsmcr/hs_auth/entities"
 	"github.com/unicsmcr/hs_auth/routers/api/models"
+	common2 "github.com/unicsmcr/hs_auth/routers/common"
 	"github.com/unicsmcr/hs_auth/services"
 	"github.com/unicsmcr/hs_auth/utils/auth"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -104,14 +104,9 @@ func (r *apiV2Router) Register(ctx *gin.Context) {
 	ctx.Status(http.StatusOK)
 
 	if r.cfg.Auth.EmailVerificationRequired {
-		verificationURIs, err := r.makeEmailVerificationURIs(*user)
+		err = r.emailService.SendEmailVerificationEmail(ctx, *user, common2.MakeEmailVerificationURIs(*user))
 		if err != nil {
-			r.logger.Warn("could not create URIs for email verification", zap.Error(err))
-		} else {
-			err = r.emailService.SendEmailVerificationEmail(ctx, *user, verificationURIs)
-			if err != nil {
-				r.logger.Warn("could not send email verification email", zap.Error(err))
-			}
+			r.logger.Warn("could not send email verification email", zap.Error(err))
 		}
 	}
 }
@@ -395,14 +390,7 @@ func (r *apiV2Router) GetPasswordResetEmail(ctx *gin.Context) {
 		return
 	}
 
-	pwdResetURIs, err := r.makeEmailVerificationURIs(*user)
-	if err != nil {
-		r.logger.Error("could create password reset URIs", zap.Error(err))
-		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
-		return
-	}
-
-	err = r.emailService.SendPasswordResetEmail(ctx, *user, pwdResetURIs)
+	err = r.emailService.SendPasswordResetEmail(ctx, *user, common2.MakePasswordResetURIs(*user))
 	if err != nil {
 		r.logger.Error("could send password reset email", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
@@ -549,14 +537,7 @@ func (r *apiV2Router) ResendEmailVerification(ctx *gin.Context) {
 		return
 	}
 
-	verificationURIs, err := r.makeEmailVerificationURIs(*user)
-	if err != nil {
-		r.logger.Error("could create email verification URIs", zap.Error(err))
-		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
-		return
-	}
-
-	err = r.emailService.SendEmailVerificationEmail(ctx, *user, verificationURIs)
+	err = r.emailService.SendEmailVerificationEmail(ctx, *user, common2.MakeEmailVerificationURIs(*user))
 	if err != nil {
 		r.logger.Error("could send email verification email", zap.Error(err))
 		models.SendAPIError(ctx, http.StatusInternalServerError, "something went wrong")
@@ -611,24 +592,4 @@ func (r *apiV2Router) getTeamMembersCtxAware(ctx *gin.Context, teamId string) ([
 	}
 
 	return members, nil
-}
-
-func (r *apiV2Router) makeEmailVerificationURIs(user entities.User) (common.UniformResourceIdentifiers, error) {
-	apiUri, err := common.NewURIFromString(fmt.Sprintf("%s:VerifyEmail?path_id=%s", r.GetResourcePath(), user.ID.Hex()))
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create URI for API email verification resource")
-	}
-
-	// TODO: add resource for frontend email verification (https://github.com/unicsmcr/hs_auth/issues/106)
-	return []common.UniformResourceIdentifier{apiUri}, err
-}
-
-func (r *apiV2Router) makePasswordResetURIs(user entities.User) (common.UniformResourceIdentifiers, error) {
-	apiUri, err := common.NewURIFromString(fmt.Sprintf("%s:SetPassword?path_id=%s", r.GetResourcePath(), user.ID.Hex()))
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create URI for API password reset resource")
-	}
-
-	// TODO: add resource for frontend password reset (https://github.com/unicsmcr/hs_auth/issues/106)
-	return []common.UniformResourceIdentifier{apiUri}, err
 }

--- a/routers/common/common.go
+++ b/routers/common/common.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"fmt"
+	"github.com/unicsmcr/hs_auth/authorization/v2/common"
+	"github.com/unicsmcr/hs_auth/entities"
+)
+
+const ApiV2ResourcePath = "hs:hs_auth:api:v2"
+const FrontendResourcePath = "hs:hs_auth:frontend"
+
+func MakeEmailVerificationURIs(user entities.User) common.UniformResourceIdentifiers {
+	apiV2Uri, _ := common.NewURIFromString(fmt.Sprintf("%s:VerifyEmail?path_id=%s", ApiV2ResourcePath, user.ID.Hex()))
+	frontendUri, _ := common.NewURIFromString(fmt.Sprintf("%s:VerifyEmail?query_userId=%s", FrontendResourcePath, user.ID.Hex()))
+
+	return []common.UniformResourceIdentifier{apiV2Uri, frontendUri}
+}
+
+func MakePasswordResetURIs(user entities.User) common.UniformResourceIdentifiers {
+	apiV2Uri, _ := common.NewURIFromString(fmt.Sprintf("%s:SetPassword?path_id=%s", ApiV2ResourcePath, user.ID.Hex()))
+	frontendUri, _ := common.NewURIFromString(fmt.Sprintf("%s:ResetPassword?query_userId=%s", FrontendResourcePath, user.ID.Hex()))
+
+	return []common.UniformResourceIdentifier{apiV2Uri, frontendUri}
+}

--- a/routers/common/common_test.go
+++ b/routers/common/common_test.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/unicsmcr/hs_auth/entities"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"net/url"
+	"testing"
+)
+
+var testUserId = primitive.NewObjectID()
+
+func TestMakeEmailVerificationURIs(t *testing.T) {
+	uris := MakeEmailVerificationURIs(entities.User{ID: testUserId})
+
+	assert.Len(t, uris, 2)
+
+	apiV2Uri, err := uris[0].MarshalJSON()
+	assert.NoError(t, err)
+	unescapedApiV2Uri, err := url.QueryUnescape(string(apiV2Uri))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("\"hs:hs_auth:api:v2:VerifyEmail?path_id=%s\"", testUserId.Hex()), unescapedApiV2Uri)
+	frontendUri, err := uris[1].MarshalJSON()
+	assert.NoError(t, err)
+	unescapedFrontendUri, err := url.QueryUnescape(string(frontendUri))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("\"hs:hs_auth:frontend:VerifyEmail?query_userId=%s\"", testUserId.Hex()), unescapedFrontendUri)
+}
+
+func TestMakePasswordResetURIs(t *testing.T) {
+	uris := MakePasswordResetURIs(entities.User{ID: testUserId})
+
+	assert.Len(t, uris, 2)
+
+	apiV2Uri, err := uris[0].MarshalJSON()
+	assert.NoError(t, err)
+	unescapedApiV2Uri, err := url.QueryUnescape(string(apiV2Uri))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("\"hs:hs_auth:api:v2:SetPassword?path_id=%s\"", testUserId.Hex()), unescapedApiV2Uri)
+	frontendUri, err := uris[1].MarshalJSON()
+	assert.NoError(t, err)
+	unescapedFrontendUri, err := url.QueryUnescape(string(frontendUri))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("\"hs:hs_auth:frontend:ResetPassword?query_userId=%s\"", testUserId.Hex()), unescapedFrontendUri)
+}

--- a/routers/frontend/router.go
+++ b/routers/frontend/router.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	authV2 "github.com/unicsmcr/hs_auth/authorization/v2"
+	"github.com/unicsmcr/hs_auth/routers/common"
 	"github.com/unicsmcr/hs_auth/utils"
 	"net/http"
 
@@ -15,7 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const resourcePath = "hs:hs_auth:frontend"
 const authCookieName = "Authorization"
 
 func jwtProvider(ctx *gin.Context) string {
@@ -59,18 +59,19 @@ type templateDataModel struct {
 
 type frontendRouter struct {
 	models.BaseRouter
-	logger       *zap.Logger
-	cfg          *config.AppConfig
-	env          *environment.Env
-	userService  services.UserService
-	teamService  services.TeamService
-	emailService services.EmailService
-	authorizer   authV2.Authorizer
-	timeProvider utils.TimeProvider
+	logger         *zap.Logger
+	cfg            *config.AppConfig
+	env            *environment.Env
+	userService    services.UserService
+	teamService    services.TeamService
+	emailService   services.EmailService
+	emailServiceV2 services.EmailServiceV2
+	authorizer     authV2.Authorizer
+	timeProvider   utils.TimeProvider
 }
 
 func (r *frontendRouter) GetResourcePath() string {
-	return resourcePath
+	return common.FrontendResourcePath
 }
 
 func (r *frontendRouter) GetAuthToken(ctx *gin.Context) string {
@@ -87,16 +88,19 @@ func (r *frontendRouter) HandleUnauthorized(ctx *gin.Context) {
 	invalidJWTHandler(ctx)
 }
 
-func NewRouter(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env, userService services.UserService, teamService services.TeamService, emailService services.EmailService, authorizer authV2.Authorizer, timeProvider utils.TimeProvider) Router {
+func NewRouter(logger *zap.Logger, cfg *config.AppConfig, env *environment.Env, userService services.UserService,
+	teamService services.TeamService, emailService services.EmailService, authorizer authV2.Authorizer,
+	timeProvider utils.TimeProvider, emailServiceV2 services.EmailServiceV2) Router {
 	return &frontendRouter{
-		logger:       logger,
-		cfg:          cfg,
-		env:          env,
-		userService:  userService,
-		teamService:  teamService,
-		emailService: emailService,
-		authorizer:   authorizer,
-		timeProvider: timeProvider,
+		logger:         logger,
+		cfg:            cfg,
+		env:            env,
+		userService:    userService,
+		teamService:    teamService,
+		emailService:   emailService,
+		authorizer:     authorizer,
+		timeProvider:   timeProvider,
+		emailServiceV2: emailServiceV2,
 	}
 }
 

--- a/routers/frontend/router_test.go
+++ b/routers/frontend/router_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	mock_v2 "github.com/unicsmcr/hs_auth/mocks/authorization/v2"
+	"github.com/unicsmcr/hs_auth/routers/common"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,7 +32,7 @@ func Test_RegisterRoutes__should_register_required_routes(t *testing.T) {
 	mockTeamService := mock_services.NewMockTeamService(ctrl)
 	mockAuthorizer := mock_v2.NewMockAuthorizer(ctrl)
 
-	router := NewRouter(zap.NewNop(), &config.AppConfig{Name: "test"}, env, mockUserService, mockTeamService, mockEmailService, mockAuthorizer, nil)
+	router := NewRouter(zap.NewNop(), &config.AppConfig{Name: "test"}, env, mockUserService, mockTeamService, mockEmailService, mockAuthorizer, nil, nil)
 
 	tests := []struct {
 		route  string
@@ -119,7 +120,7 @@ func Test_RegisterRoutes__should_register_required_routes(t *testing.T) {
 
 func TestRouter_GetResourcePath(t *testing.T) {
 	router := &frontendRouter{}
-	assert.Equal(t, "hs:hs_auth:frontend", router.GetResourcePath())
+	assert.Equal(t, common.FrontendResourcePath, router.GetResourcePath())
 }
 
 func TestRouter_GetAuthToken__returns_correct_token(t *testing.T) {

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -64,7 +64,7 @@ func InitializeServer() (Server, error) {
 		return Server{}, err
 	}
 	apiv2Router := v2_3.NewAPIV2Router(logger, appConfig, authorizer, userService, teamService, tokenService, emailServiceV2, timeProvider)
-	router := frontend.NewRouter(logger, appConfig, env, userService, teamService, emailService, authorizer, timeProvider)
+	router := frontend.NewRouter(logger, appConfig, env, userService, teamService, emailService, authorizer, timeProvider, emailServiceV2)
 	mainRouter := routers.NewMainRouter(logger, apiv1Router, apiv2Router, router)
 	server := NewServer(mainRouter, env)
 	return server, nil


### PR DESCRIPTION
For issue #106 

Migrates the frontend operation `Register` to use auth system v2.

Also resolves the following TODOs:
- https://github.com/unicsmcr/hs_auth/blob/master/routers/api/v2/users.go#L632
- https://github.com/unicsmcr/hs_auth/blob/master/routers/api/v2/users.go#L622