### PR TITLE
feat: Move profile page to /profile

### DIFF
--- a/routers/frontend/router.go
+++ b/routers/frontend/router.go
@@ -36,6 +36,7 @@ type Router interface {
 	LeaveTeam(*gin.Context)
 	UpdateUser(*gin.Context)
 	ProfilePage(*gin.Context)
+	RedirectToEntryPage(*gin.Context)
 }
 
 type frontendRouter struct {
@@ -90,7 +91,8 @@ func (r *frontendRouter) RegisterRoutes(routerGroup *gin.RouterGroup) {
 		frontendRouter: *r,
 	}
 
-	routerGroup.GET("", r.authorizer.WithAuthMiddleware(r, r.ProfilePage))
+	routerGroup.GET("", r.RedirectToEntryPage)
+	routerGroup.GET("/profile", r.authorizer.WithAuthMiddleware(r, r.ProfilePage))
 	routerGroup.GET("login", r.LoginPage)
 	routerGroup.POST("login", r.Login)
 	routerGroup.GET("logout", r.Logout)

--- a/routers/frontend/routes.go
+++ b/routers/frontend/routes.go
@@ -16,6 +16,14 @@ import (
 
 const returnToCookie = "ReturnTo"
 
+func (r *frontendRouter) RedirectToEntryPage(ctx *gin.Context) {
+	if len(r.GetAuthToken(ctx)) != 0 {
+		ctx.Redirect(http.StatusPermanentRedirect, "/profile")
+	} else {
+		ctx.Redirect(http.StatusPermanentRedirect, "/login")
+	}
+}
+
 func (r *frontendRouter) ProfilePage(ctx *gin.Context) {
 	r.renderPage(ctx, profilePage, http.StatusOK, nil, "")
 }

--- a/routers/frontend/routes_test.go
+++ b/routers/frontend/routes_test.go
@@ -1242,6 +1242,30 @@ func TestFrontendRouter_ProfilePage(t *testing.T) {
 	assert.Equal(t, http.StatusOK, setup.w.Code)
 }
 
+func TestFrontendRouter_RedirectToEntryPage__should_redirect_to_login_when_auth_token_is_unavailable(t *testing.T) {
+	setup := setupTest(t, nil)
+	defer setup.ctrl.Finish()
+
+	setup.testCtx.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	setup.router.RedirectToEntryPage(setup.testCtx)
+
+	assert.Equal(t, http.StatusPermanentRedirect, setup.w.Code)
+	assert.Equal(t, "/login", setup.w.HeaderMap["Location"][0])
+}
+
+func TestFrontendRouter_RedirectToEntryPage__should_redirect_to_profile_when_auth_token_is_available(t *testing.T) {
+	setup := setupTest(t, nil)
+	defer setup.ctrl.Finish()
+
+	attachAuthCookie(setup.testCtx)
+
+	setup.router.RedirectToEntryPage(setup.testCtx)
+
+	assert.Equal(t, http.StatusPermanentRedirect, setup.w.Code)
+	assert.Equal(t, "/profile", setup.w.HeaderMap["Location"][0])
+}
+
 func mockRenderPageCall(setup *testSetup) {
 	setup.mockAuthorizer.EXPECT().GetAuthorizedResources(setup.testCtx, gomock.Any(), gomock.Any()).
 		Return(nil, nil).Times(1)


### PR DESCRIPTION
Resolves #144 

Moves the profile page to `/profile` and implements a handler for `/` to redirect the user to either `/login` or `/profile`.