### PR TITLE
fix: ReturnTo in navbar displayed when ReturnTo cookie is invalid

### DIFF
--- a/routers/frontend/routes.go
+++ b/routers/frontend/routes.go
@@ -82,7 +82,7 @@ func (r *frontendRouter) Login(ctx *gin.Context) {
 	if err != nil && len(returnTo) == 0 {
 		returnTo = "/"
 	}
-	ctx.SetCookie(returnToCookie, returnTo, 0, "", r.cfg.DomainName, r.cfg.UseSecureCookies, true)
+	ctx.SetCookie(returnToCookie, returnTo, -1, "", r.cfg.DomainName, r.cfg.UseSecureCookies, true)
 	ctx.Redirect(http.StatusMovedPermanently, returnTo)
 }
 

--- a/templates/partials/navbar.gohtml
+++ b/templates/partials/navbar.gohtml
@@ -1,6 +1,6 @@
 <div class="row justify-content-end">
     <div class="col-lg-2 col-md-5 col-7">
-          {{if ne .ReturnTo "/"}}
+          {{if ne .ReturnTo ""}}
             <a class="nav-link" href="{{.ReturnTo}}">
             <i class="fas fa-fast-backward"></i>
             Back to previous page


### PR DESCRIPTION
I noticed while testing that the navbar component "return to previous location" gets displayed even when the `ReturnTo` cookie is invalid.

This PR updates the template for the "return to previous location" to render the component only if the `ReturnTo` cookie is not empty.