### PR TITLE
fix: Links in emails are rendered as plaintext

### DIFF
--- a/templates/emails/emailVerify_email.gohtml
+++ b/templates/emails/emailVerify_email.gohtml
@@ -145,7 +145,7 @@
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Click this link to verify your email:</p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
-<p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">{{.Link}}</p>
+<a style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;" href="{{.Link}}">Verify Email</a>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Thanks!</p>
@@ -227,7 +227,7 @@
 <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; font-family: Arial, sans-serif"><![endif]-->
 <div style="color:#555555;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;line-height:1.2;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px;">
 <div style="font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.2; color: #555555; mso-line-height-alt: 14px;">
-<p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">© <a href="https://unicsmcr.com" rel="noopener" style="text-decoration: underline; color: #0068A5;" target="_blank">UniCS</a> 2019</p>
+<p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">© <a href="https://unicsmcr.com" rel="noopener" style="text-decoration: underline; color: #0068A5;" target="_blank">UniCS</a> 2020</p>
 <p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">Kilburn Building M13 9 PL</p>
 <p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">Manchester, United Kingdom</p>
 </div>

--- a/templates/emails/passwordReset_email.gohtml
+++ b/templates/emails/passwordReset_email.gohtml
@@ -143,7 +143,7 @@
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Click this link for further instructions:</p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
-<p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">{{.Link}}</p>
+<a href="{{.Link}}" style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Reset Password</a>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;"> </p>
 <p style="font-size: 14px; line-height: 1.2; mso-line-height-alt: 17px; margin: 0;">Thanks!</p>
@@ -225,7 +225,7 @@
 <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; font-family: Arial, sans-serif"><![endif]-->
 <div style="color:#555555;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;line-height:1.2;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px;">
 <div style="font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 12px; line-height: 1.2; color: #555555; mso-line-height-alt: 14px;">
-<p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">© <a href="https://unicsmcr.com" rel="noopener" style="text-decoration: underline; color: #0068A5;" target="_blank">UniCS</a> 2019</p>
+<p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">© <a href="https://unicsmcr.com" rel="noopener" style="text-decoration: underline; color: #0068A5;" target="_blank">UniCS</a> 2020</p>
 <p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">Kilburn Building M13 9 PL</p>
 <p style="font-size: 14px; line-height: 1.2; text-align: center; mso-line-height-alt: 17px; margin: 0;">Manchester, United Kingdom</p>
 </div>


### PR DESCRIPTION
This PR fixes the email templates to render the links as actual hyperlinks rather than plaintext.

Also updates the year in the emails to 2020.