### PR TITLE
Add hs_discord resources to role config

### DIFF
--- a/config/role/role.yaml
+++ b/config/role/role.yaml
@@ -41,6 +41,8 @@ role:
     - "hs:hs_apply:Dashboard:dashboard"
     - "hs:hs_apply:Application:cancel"
     - "hs:hs_hub"
+    - "hs:hs_discord:guild:attendee"
+    - "hs:hs_discord:bot:sync"
   volunteer:
     - "hs:hs_auth:frontend:ProfilePage"
     - "hs:hs_auth:frontend:ProfilePageComponents:Default"
@@ -50,5 +52,7 @@ role:
     - "hs:hs_auth:api:v2:GetAuthorizedResources"
     - "hs:hs_apply:Dashboard:dashboard"
     - "hs:hs_hub"
+    - "hs:hs_discord:guild:volunteer"
+    - "hs:hs_discord:bot"
   organiser:
     - "hs"


### PR DESCRIPTION
This PR defines the resources required by hs_discord, and also configures the various roles in role.yaml with the correct hs_discord resources.

-----

### Role-based Resources

These resources declare the 4 roles that users can be assigned in the Discord server. They should not be used by hs_discord to derive a user's permissions to perform an action. The associated Discord roles will have permissions, e.g. organisers will be able to post in the announcements channel. The attendee role on the other hand is purely decorative.

- `hs:hs_discord:guild:organiser`
- `hs:hs_discord:guild:volunteer`
- `hs:hs_discord:guild:sponsor`
- `hs:hs_discord:guild:attendee`

### Bot resources

- `hs:hs_discord:bot:id` - permits access to the `!id` command on the Discord server
- `hs:hs_discord:bot:whois` - permits access to the `!whois` command to match a user's Discord profile to their HackerSuite profile
- `hs:hs_discord:bot:mentor` - permits access to the `!mentor ...` command, allowing users to set languages/resources they'd like to mentor in.
- `hs:hs_discord:bot:mute` - permits access to the `!mute` command
- `hs:hs_discord:bot:unmute` - permits access to the `!unmute` command
- `hs:hs_discord:bot:stats` - permits access to `!stats`, which gives an overview of how many teams and attendees there are on the Discord
- `hs:hs_discord:bot:sync`
  - permits the user to link their HackerSuite account to their Discord account
  - permits access to `!sync`. This will update the user's roles using their latest HackerSuite info (team and "level" of user as described above)
- `hs:hs_discord:bot:tweet_management` - allows users to approve/reject tweets to be displayed within the server.
