### PR TITLE
fix: Replace null response from GetAuthorizedResources with empty array

### DIFF
--- a/routers/api/v2/tokens.go
+++ b/routers/api/v2/tokens.go
@@ -160,6 +160,9 @@ func (r *apiV2Router) GetAuthorizedResources(ctx *gin.Context) {
 		}
 		return
 	}
+	if authorizedUris == nil {
+		authorizedUris = common.UniformResourceIdentifiers{}
+	}
 
 	ctx.JSON(http.StatusOK, getAuthorizedResourcesRes{
 		AuthorizedUris: authorizedUris,

--- a/routers/api/v2/tokens_test.go
+++ b/routers/api/v2/tokens_test.go
@@ -389,6 +389,18 @@ func TestApiV2Router_GetAuthorizedResources(t *testing.T) {
 				nil,
 			},
 		},
+		{
+			name:            "with empty response",
+			testAllowedURIs: "[\"hs:hs_auth\"]",
+			prep: func(setup *tokensTestSetup) {
+				setup.mockAuthorizer.EXPECT().GetAuthorizedResources(setup.testCtx, gomock.Any(), gomock.Any()).
+					Return(nil, nil).Times(1)
+			},
+			wantResCode: http.StatusOK,
+			wantRes: &getAuthorizedResourcesRes{
+				AuthorizedUris: common.UniformResourceIdentifiers{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Updates the `GetAuthorizedResources` operations to return an empty array instead of null when none of the requested resources are authorized.